### PR TITLE
Feat/nanopb pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,18 @@
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
+name: Build CI
+
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     container: ros:galactic
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v2
         with:
+          submodules: recursive
           path: src/urc-software
-          submodules: true
+          
       - name: Install Dependencies
         shell: bash
         run: |
@@ -19,6 +20,7 @@ jobs:
           sudo apt-get update
           rosdep update --rosdistro=galactic
           rosdep install --from-paths . --ignore-src -y
+
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
         run: |
           source /opt/ros/galactic/setup.bash
           sudo apt-get update
-          git submodule update --init --recursive
           rosdep update --rosdistro=galactic
           rosdep install --from-paths . --ignore-src -y
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           source /opt/ros/galactic/setup.bash
           sudo apt-get update
+          git submodule update --init --recursive
           rosdep update --rosdistro=galactic
           rosdep install --from-paths . --ignore-src -y
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,17 @@
-name: ci
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
   workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-20.04
     container: ros:galactic
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/urc-software
+          submodules: true
       - name: Install Dependencies
         shell: bash
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "urc_platform/nanopb/external/nanopb"]
-	path = urc_platform/nanopb/external/nanopb
+[submodule "external/nanopb"]
+	path = external/nanopb
 	url = https://github.com/nanopb/nanopb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "urc_platform/nanopb/external/nanopb"]
+	path = urc_platform/nanopb/external/nanopb
+	url = https://github.com/nanopb/nanopb

--- a/urc_platform/CMakeLists.txt
+++ b/urc_platform/CMakeLists.txt
@@ -61,6 +61,8 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+add_subdirectory(nanopb)
+
 ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})

--- a/urc_platform/nanopb/CMakeLists.txt
+++ b/urc_platform/nanopb/CMakeLists.txt
@@ -10,6 +10,7 @@ nanopb_generate_cpp(
   PROTO_HDRS
   proto/urc.proto
 )
+include_directories(${NANOPB_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} SHARED
   ${PROTO_HDRS}
@@ -17,12 +18,6 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 target_link_libraries(${PROJECT_NAME})
-
-target_include_directories(${PROJECT_NAME}
-  INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
-)
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(Nanopb)

--- a/urc_platform/nanopb/CMakeLists.txt
+++ b/urc_platform/nanopb/CMakeLists.txt
@@ -1,0 +1,26 @@
+find_package(ament_cmake REQUIRED)
+find_package(Protobuf REQUIRED)
+
+protobuf_generate_cpp(
+  PROTOBUF_SRCS
+  PROTOBUF_HDRS
+  proto/urc.proto
+)
+
+add_library(${PROJECT_NAME} SHARED
+  ${PROTOBUF_HDRS}
+  ${PROTOBUF_SRCS}
+)
+
+target_link_libraries(${PROJECT_NAME}
+  protobuf::libprotobuf
+)
+
+target_include_directories(${PROJECT_NAME}
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(Protobuf)

--- a/urc_platform/nanopb/CMakeLists.txt
+++ b/urc_platform/nanopb/CMakeLists.txt
@@ -1,8 +1,7 @@
 find_package(ament_cmake REQUIRED)
 find_package(Protobuf REQUIRED)
 
-set(NANOPB_SRC_ROOT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/external/nanopb)
-set(CMAKE_MODULE_PATH ${NANOPB_SRC_ROOT_FOLDER}/extra)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../external/nanopb/extra)
 find_package(Nanopb REQUIRED)
 
 nanopb_generate_cpp(
@@ -12,12 +11,4 @@ nanopb_generate_cpp(
 )
 include_directories(${NANOPB_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} SHARED
-  ${PROTO_HDRS}
-  ${PROTO_GENERATED_SRCS}
-)
-
-target_link_libraries(${PROJECT_NAME})
-
-ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(Nanopb)

--- a/urc_platform/nanopb/CMakeLists.txt
+++ b/urc_platform/nanopb/CMakeLists.txt
@@ -1,20 +1,22 @@
 find_package(ament_cmake REQUIRED)
 find_package(Protobuf REQUIRED)
 
-protobuf_generate_cpp(
-  PROTOBUF_SRCS
-  PROTOBUF_HDRS
+set(NANOPB_SRC_ROOT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/external/nanopb)
+set(CMAKE_MODULE_PATH ${NANOPB_SRC_ROOT_FOLDER}/extra)
+find_package(Nanopb REQUIRED)
+
+nanopb_generate_cpp(
+  PROTO_GENERATED_SRCS
+  PROTO_HDRS
   proto/urc.proto
 )
 
 add_library(${PROJECT_NAME} SHARED
-  ${PROTOBUF_HDRS}
-  ${PROTOBUF_SRCS}
+  ${PROTO_HDRS}
+  ${PROTO_GENERATED_SRCS}
 )
 
-target_link_libraries(${PROJECT_NAME}
-  protobuf::libprotobuf
-)
+target_link_libraries(${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}
   INTERFACE
@@ -23,4 +25,4 @@ target_include_directories(${PROJECT_NAME}
 )
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(Protobuf)
+ament_export_dependencies(Nanopb)

--- a/urc_platform/nanopb/proto/urc.proto
+++ b/urc_platform/nanopb/proto/urc.proto
@@ -1,0 +1,42 @@
+syntax = "proto2";
+
+// Filled out by mbed (server), sent to the ROS node (client)
+message ResponseMessage {
+    optional float p_l = 1;
+    optional float p_r = 2;
+    optional float i_l = 3;
+    optional float i_r = 4;
+    optional float d_l = 5;
+    optional float d_r = 6;
+
+    optional float speed_l = 7;
+    optional float speed_r = 8;
+    optional float dt_sec = 9;
+
+    optional float voltage = 10;
+    optional bool estop = 11;
+
+    optional float kv_l = 12;
+    optional float kv_r = 13;
+
+    // Output sent to motors
+    // Should range from 0 - 255 (ie. uchar)
+    optional uint32 left_output = 14;
+    optional uint32 right_output = 15;
+}
+
+// Filled out by ROS node, sent to mbed
+message RequestMessage {
+    optional float p_l = 1;
+    optional float p_r = 2;
+    optional float i_l = 3;
+    optional float i_r = 4;
+    optional float d_l = 5;
+    optional float d_r = 6;
+
+    optional float speed_l = 7 [default = 0];
+    optional float speed_r = 8 [default = 0];
+
+    optional float kv_l = 9;
+    optional float kv_r = 10;
+}

--- a/urc_platform/package.xml
+++ b/urc_platform/package.xml
@@ -8,7 +8,6 @@
   <license>MIT</license>
 
   <depend>protobuf-dev</depend>
-  <depend>nanopb-dev</depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/urc_platform/package.xml
+++ b/urc_platform/package.xml
@@ -8,6 +8,7 @@
   <license>MIT</license>
 
   <depend>protobuf-dev</depend>
+  <depend>nanopb-dev</depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/urc_platform/package.xml
+++ b/urc_platform/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="aidan.stickan@gmail.com">a-stickan</maintainer>
   <license>MIT</license>
 
+  <depend>protobuf-dev</depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
# Description
URC needs a way to transmit messages on a network, so this PR adds nanopb to link messages in proto file format.

This PR does the following:
- Adds nanopb submodule
- Adds .proto file specifying message details
- Adds a cmake to link nanopb proto files to project

Fixes #28 

Expectation: nanopb added, and cmake links proto files

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
