### PR TITLE
Bug/ipynb spam

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ipynb linguist-vendored
+*.bib linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-*.ipynb linguist-vendored
-*.bib linguist-vendored
+*.ipynb linguist-detectable=false
+*.bib linguist-detectable=false
+*.html linguist-detectable=false
+*.css linguist-detectable=false


### PR DESCRIPTION
# Description

This PR does the following:
- Adds a .gitattributes file
- Prevents linguist from detecting files of the following types
  - .ipynb
  - .bib
  - .html
  - .css

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
