### PR TITLE
bug/nanopb_export_issue

### DIFF
--- a/urc_nanopb/CMakeLists.txt
+++ b/urc_nanopb/CMakeLists.txt
@@ -41,10 +41,6 @@ target_include_directories(${PROJECT_NAME}
 )
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(
-  Protobuf
-  Nanopb
-)
 
 install(
   DIRECTORY ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
# Description

This PR does the following:
- Fixes issue where urc_platform wasn't building due to exporting Protobuf and Nanopb dependencies from urc_nanopb when
they aren't needed

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
