### PR TITLE
Feat/design_presentations

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -14,9 +14,3 @@ assignees: ''
  - Requirement 1
  - Requirement 2
  - ...
-
-## Design
-
-[Link to design document](link)
-
-_(The design phase can be omitted for "small" features, i.e. doable in a single meeting. However, if this is a subfeature of a larger feature with a design document, please link it above.)_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 # Description
-
 This PR does the following:
 - Thing 1
 - Thing 2
@@ -7,13 +6,16 @@ This PR does the following:
 
 Fixes #{{ github issue }}
 
-# Testing steps (If relevant)
+# Testing Steps (if relevant)
 ## Test Case 1
 1. Do this thing
 2. Do that thing
 3. Make the thing do the thing
 
 Expectation: The thing which does the thing does the thing
+
+# Design Presentation (only required for major additions)
+Post the link to your presentation here and [be sure to update the presentation document](../documents/design/README.md) if this PR results in a significant addition to the stack
 
 # Self Checklist
 - [ ] I have formatted my code using `ament_uncrustify --reformat`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Welcome to the RoboJackets URC software repo! This document will give you a brie
 
 [![Software Lead](https://img.shields.io/badge/Software%20Lead-Aidan%20Stickan-green?color=EEB211&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAoCAYAAAAVBmHYAAAGY0lEQVR42rWWB1BUZxDHn4K5xKCCiUYIkogi5aQfNSp2IMoJBrBMJqFpjIIeB1JknFAE6VI8qiDgUUSacIiFqEE8kKKGpgiJkkESjeKAFGm32e/kGDCjRr3szM67u/e+3+7+v/32HUXMxdtlnqen5xzy2cvLS4YStx04cGCxi4sLjbi7u/sisQdgs9na5Orh4SEn9gpsbGwk3Nzc1MhnlgdLVezZs1gsaSIRuWIF8mIP4OrqugTBs0Qyid1wUw32e3goY6C5/wd8Pur/BWZv/KpnfH19Jd+newzDjjivAfCd/hJU2s/P71JmZqbg4sWLT6qqqtj/hTcD3U9SctoFbiTj5NAdi87eRksYaLEaHL7L5A60bZEfh0ekpaVBXV3dhNfW1m57E7hw/ic0uJS1/Hl98SrQ05ABCYlpYG0uB/3Nm2C4lfno+d2Nigi/fv78+Snw+vr6M6+Dx8vLfgS3L6wdvcVbDXNmzQD8bcJzYhgEDqQChNdeuXLl5cyLXwVWmS0lCb+eXTM60GIB6sqzCXCKp4XpCOGDLeYdCK9CmwwXIJyJz03De5bojAnyzJmULO+44QhZnBur9y+wDl0aehuEskD3DYOugICASoRBeXk55ObmQmkpbyieE+v106FDySdOnICjR4+OYgA5IXz4DnM3WUg8zJs+BWygJQOdfFPhvWeNq+ABX6k4NDSUX11dDbGxsVBSUgLh4eGQnJwsiI6OHsUrREZGCoKCguZR0GwjhQsfiuCP678GN6clYLvxc0gO0kIZLIS/9zWthS6+0kB92SaruLi4zpMnTwLC4NSpU5CSkgJ8Ph+uXbuml52dfQ/v3XqR9V0LF7L4dU7ADyqX9jWfU9987Nixcg6Hcy81NRWuXr2KkpRCTU0N0b03jsMpjo+Le5yVmXlOBL/8WnDjauioUHvacVVF15PN2ot6c7HH230OHpzcKd3YilaREeEDIUcCISsrqwI1n04Nt26+/yrwswYTuFdh1JWWFFh42N8vj6Gt7WCycsUYzpsnbHTM2BvBX2GAGRTa6dOn/fPy8oZRmh5/f386hZDbL0OHWpmjT28a9PJLHbp5vCKIiY7qCg0OEgQGBgoYurpgb2cHe/fs+ZO0HjVuuLEq6BnFxcUPMEALbvp31Egr03sSeGiodXNBb4OxEVkQHhJknZOT/ZzH4wFqLKisrAScJ8C0sAB7e7sxR0fHHSJ4UVFRApfLrSgsLPTHAK75+fk/v9C9jandVOnvd740bwD7VioxMXHO2bNnaeNzRKWgIP/+vn37oKysDEgfb9++HQIDD/8dEhIiL4KjJDxMIA6zX47JHMbv+dSkstLRr4eFhdlij/6BB+RCW1ubMEBMTMxihHaSALihEB8fP+Ts7Dxoampag76ZQisoKNiNhycG13+Mmm9NT0/3F43Q6dibzQkJCa0+Pj6AMHIQLuNwOi4KjtUsjgoLaMQ3FNja2gJCJ3zDhg0OhJGTk3MOoUZYwV1UQEIE/8Db27say3yEb32IiooajoiIiMGA6SK4nfas4N+y1aApYxnkJ27F08kCa2umCN5JNjcpKckW23Qlrp36glm3bp0i/mcxwbLSSOb4wBmUSYHco8+jS4XYL7r5e44aEG+8EQwAeTAykounMhz2OGyE9evXy1FvMqxCEWfFqYyMjInJpq+jw6NraMGend+CJ8sJN9Ud2ttThQH6etLgDpcOVUmau6l3MTV1jWFlVTVg73eGXY72sGLFCsD9AQ4nFJIitsF4RTZvDdbFiRz2vXzFldhl4LJDE6yYa8DSkgm4weDk5CRsS/fd5mO5nopz3hpuLEVta0hRbiTZ3c/T7B8bOz3Y08OF4OAfwcxslcAOT6v5ar1e8m/treF2dJpZqMPShwW+Sn81l3xzk+gs8u4WFt/DQReYq5XOUO9on2lra9fp4kzR1NQUbNlkNJqVsvPpUD/3cUeJcQ1W1N+cS5d6V/hcJSWlJg0NDcAgoKenB0ZGRmC2dmVfKlup/U6Gcgb1HvalrKzsvYULF4K8vDyQK3E5ObluGo32A/We9ilm+ws66OjoEGlAVVX1mYqKihElBpNGWerV1dVBS0sLGAzGkKKiogPZC3HAZRcsWNBOpFBQUAAZGRnSGR9QYrIP9fX1ywwMDMDQ0DCcErPNRFmq0K/jZxNK3IYjdZe5uTntbdf9A8TXLsMW/IC6AAAAAElFTkSuQmCC)](https://github.com/a-stickan)
 
----
 
 ## Directory Structure
 
@@ -36,7 +35,6 @@ Welcome to the RoboJackets URC software repo! This document will give you a brie
  * **urc_util**
     *A collection of utility nodes and classes*
 
----
 
 ## Installation Instructions
 
@@ -46,13 +44,13 @@ Welcome to the RoboJackets URC software repo! This document will give you a brie
 
 [Docker Installation Instructions](documents/installation/docker_installation.md)
 
----
 
 ## Helpful Resources
 
 [Useful commands](documents/helpers/useful_commands.md)
 
----
+[Design presentations](documents/design/README.md)
+
 
 ## Contributing
 Join our slack [here!](https://robojackets.slack.com/)

--- a/documents/design/README.md
+++ b/documents/design/README.md
@@ -1,6 +1,16 @@
 # Major Design Presentations
 
-Every major design decision is required to have an accompanying presentation for the PR. Below is a collection of past presentations for major additions to the URC software stack.
+Every major design decision is required to have an accompanying presentation for the PR. The presentation should include:
+* Background on the task/purpose
+* Major technologies/packages/libraries used
+* Research/reference resources
+* A clear explanation of why that design was chosen
+* Any future development to be done on the task
+
+[RJ General Slides Theme](https://docs.google.com/presentation/d/14omGRc-cdEDDEFdOUnVKgbbW5EMFX9UyO-QmpGfILho/edit?usp=sharing)
+
+
+Below is a collection of past presentations for major additions to the URC software stack.
 
 ## 2022 - 2023
 

--- a/documents/design/README.md
+++ b/documents/design/README.md
@@ -1,19 +1,7 @@
-# Design Docs
+# Major Design Presentations
 
-## 2020/2021 Projects
+Every major design decision is required to have an accompanying presentation for the PR. Below is a collection of past presentations for major additions to the URC software stack.
 
-* **Mapping & Navigation**
-    *
+## 2022 - 2023
 
-* **Perception**
-    * 
-
-* **Simulation**
-    * 
-
-* **Other**
-    * 
-
-## Templates
-
-* [New Member Projects](new_member_project.md)
+* ### [Teleoperations Stack](https://docs.google.com/presentation/d/14omGRc-cdEDDEFdOUnVKgbbW5EMFX9UyO-QmpGfILho/edit?usp=sharing)

--- a/documents/design/new_member_project.md
+++ b/documents/design/new_member_project.md
@@ -38,7 +38,7 @@ be sure to describe that here. If your solution requires more research to implem
 what kind of topics you need look at. Link any research papers/articles that you find here.
 
 **Of course, if you have _any_ questions or concerns, feel free to bring them up at any time.
-If you ever feel lost or don't know what to do or work on, Oswin or any old software member
+If you ever feel lost or don't know what to do or work on, Vivek, Aidan, or any other boomer software member
 can help you out. You are not expected to know every technical detail about the project. Expressing
 what you don't know will make it easier to do research and ask for help.** 
 


### PR DESCRIPTION
# Description

This PR does the following:
- Adds a document for tracking design presentations
- Adds the teleoperations stack presentation to the design document
- Updates PR template to indicate presentations are now mandatory for major stack additions
- Formatting updates

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
