### PR TITLE
Docker with Gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,15 @@ Welcome to the RoboJackets URC software repo! This document will give you a brie
 
 ## Installation Instructions
 
-### Linux, Ubuntu 22.04
+### Ubuntu 22.04
 
 [Ubuntu 22.04 Installation Instructions](documents/installation/ubuntu_installation.md)
 
-### Linux, Non-Ubuntu 22.04
+### Windows Subsystem for Linux (WSL)
 
-[Docker Installation Instructions](documents/installation/docker_installation.md)
+[Windows Subsystem for Linux (WSL) Installation Instructions](documents/installation/wsl_installation.md)
 
-### Windows
-
-First, follow [Windows Subsystem for Linux (WSL) Installation Instructions](documents/installation/wsl_installation.md)
-
-Then, proceed with [Ubuntu 22.04 Installation Instructions](documents/installation/ubuntu_installation.md)
-
-### MacOS
+### Docker with GUI
 
 [Docker Installation Instructions](documents/installation/docker_installation.md)
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,21 @@ Welcome to the RoboJackets URC software repo! This document will give you a brie
 
 ## Installation Instructions
 
+### Linux, Ubuntu 22.04
+
 [Ubuntu 22.04 Installation Instructions](documents/installation/ubuntu_installation.md)
 
-[Windows Subsystem for Linux (WSL) Installation Instructions](documents/installation/wsl_installation.md)
+### Linux, Non-Ubuntu 22.04
+
+[Docker Installation Instructions](documents/installation/docker_installation.md)
+
+### Windows
+
+First, follow [Windows Subsystem for Linux (WSL) Installation Instructions](documents/installation/wsl_installation.md)
+
+Then, proceed with [Ubuntu 22.04 Installation Instructions](documents/installation/ubuntu_installation.md)
+
+### MacOS
 
 [Docker Installation Instructions](documents/installation/docker_installation.md)
 

--- a/docker_gui/Dockerfile
+++ b/docker_gui/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p src
 # Set up VNC server
 RUN apt-get update && apt-get install -y x11vnc xvfb terminator && apt-get clean
 RUN mkdir ~/.vnc
-RUN x11vnc -storepasswd 1234 ~/.vnc/passwd
+RUN x11vnc -storepasswd urc-2023 ~/.vnc/passwd
 
 EXPOSE 8080 5900
 RUN apt-get install -y novnc websockify wget

--- a/docker_gui/Dockerfile
+++ b/docker_gui/Dockerfile
@@ -28,5 +28,6 @@ EXPOSE 8080 5900
 RUN apt-get install -y novnc websockify wget
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+RUN sed -i -e 's/\r$//' /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker_gui/Dockerfile
+++ b/docker_gui/Dockerfile
@@ -12,12 +12,30 @@ RUN apt-get update --fix-missing && apt-get -y install \
     ssh \
     python3-pip \
     libeigen3-dev \
+    python3-colcon-common-extensions \
+    python3-rosdep \
     && apt-get clean
 
 # Initialize colcon workspace
 RUN mkdir -p /colcon_ws
 WORKDIR /colcon_ws
 RUN mkdir -p src
+
+# Clone git repo
+WORKDIR /colcon_ws/src
+RUN rm -rf urc-software
+RUN git clone https://github.com/RoboJackets/urc-software.git --recursive
+
+# Install our ROS dependecies
+WORKDIR /colcon_ws
+RUN rosdep update
+RUN apt-get update --fix-missing
+RUN rosdep install --from-paths src --ignore-src -r -y
+
+# Setup bashrc
+RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc \
+    && echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bashrc \
+    && echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc
 
 # Set up VNC server
 RUN apt-get update && apt-get install -y x11vnc xvfb terminator && apt-get clean

--- a/docker_gui/Dockerfile
+++ b/docker_gui/Dockerfile
@@ -1,0 +1,32 @@
+FROM ros:humble-ros-base
+LABEL maintainer="vivekmhatre7686@gmail.com"
+
+# Setup apt to be happy with no console input
+ARG DEBIAN_FRONTEND=noninteractive
+
+# setup apt tools and other goodies we want
+RUN apt-get update --fix-missing && apt-get -y install \
+    apt-utils \
+    git \
+    software-properties-common \
+    ssh \
+    python3-pip \
+    libeigen3-dev \
+    && apt-get clean
+
+# Initialize colcon workspace
+RUN mkdir -p /colcon_ws
+WORKDIR /colcon_ws
+RUN mkdir -p src
+
+# Set up VNC server
+RUN apt-get update && apt-get install -y x11vnc xvfb terminator && apt-get clean
+RUN mkdir ~/.vnc
+RUN x11vnc -storepasswd 1234 ~/.vnc/passwd
+
+EXPOSE 8080 5900
+RUN apt-get install -y novnc websockify wget
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+RUN chmod +x /entrypoint.sh

--- a/docker_gui/entrypoint.sh
+++ b/docker_gui/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+x11vnc -forever -usepw -create &
+
+websockify -D --web=/usr/share/novnc/ --cert=/etc/ssl/certs/XRamp_Global_CA_Root.pem 8080 localhost:5900
+
+# Start Terminal emulator
+/bin/bash

--- a/docker_gui/entrypoint.sh
+++ b/docker_gui/entrypoint.sh
@@ -4,4 +4,5 @@ x11vnc -forever -usepw -create &
 websockify -D --web=/usr/share/novnc/ --cert=/etc/ssl/certs/XRamp_Global_CA_Root.pem 8080 localhost:5900
 
 # Start Terminal emulator
-/bin/bash
+# /bin/bash
+terminator

--- a/docker_gui/entrypoint.sh
+++ b/docker_gui/entrypoint.sh
@@ -4,5 +4,4 @@ x11vnc -forever -usepw -create &
 websockify -D --web=/usr/share/novnc/ --cert=/etc/ssl/certs/XRamp_Global_CA_Root.pem 8080 localhost:5900
 
 # Start Terminal emulator
-# /bin/bash
-terminator
+/bin/bash

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -19,6 +19,16 @@ To check that everything installed OK, you should be able to open the command li
 docker
 ```
 
+### INSTALLATION NOTES:
+* It's probably a good idea to restart your computer once you install Docker.
+* Docker has to be running before you can use it. When you install Docker, it usually enables itself upon the computer turning on. If this isn't the case, be sure to launch Docker before proceeding.
+* For Linux users: I recommed adding youself to the `docker` group. Being a member of the `docker` group allows you to run `docker` without `sudo`. After running the following two commands, log back out and in again for the changes to take affect.
+
+```bash
+sudo groupadd docker
+sudo usermod -aG docker $USER
+```
+
 ## 2. Install VS Code (Highly Recommended)
 
 You do not have to use VS Code. However, VS Code has very nice extensions for using Docker containers.
@@ -49,21 +59,27 @@ Navigate to the directory `docker_gui` and run:
 docker build -t robojackets/urc-baseimage .
 ```
 
-Run the command as a superuser if you get permission errors.
+## 5. Create Docker Volume
 
-## 5. Create Docker Container
+Create a Docker volume that will hold the `urc-software` repository. The Docker volume will store your data seperately from the container itself. As a result, you can delete the container without losing your changes.
+
+```bash
+docker volume create urc_software_volume
+```
+
+## 6. Create Docker Container
 
 To create a Docker container from the newly created image `robojackets/urc-baseimage`, run
 
 ```bash
-docker container create -i -t -p=8080:8080 --name=urc_software_container robojackets/urc-baseimage
+docker container create -i -t -p=8080:8080 -v=urc_software_volume:/colcon_ws/src --name=urc_software_container robojackets/urc-baseimage
 ```
 
-## 6. Launch Docker Container
+## 7. Launch Docker Container
 
 You can launch your newly created Docker container using the command line or VS Code.
 
-### 6a. Launch Docker Container Using VS Code
+### 7a. Launch Docker Container Using VS Code
 
 First, make sure that you have the `Remote - Containers` extension installed.
 
@@ -73,12 +89,12 @@ To launch the container in VS Code, either
 * right click the container and select `Attach to Container`.
 * hover over the container and click on the folder with a plus.
 
-### 6b. Launch Docker Container Using Command Line
+### 7b. Launch Docker Container Using Command Line
 
 To run the Docker container in the command line, run
 
 ```bash
-docker start -i -p=8080:8080 urc_software_container
+docker start -i urc_software_container
 ```
 
 If you want to open another terminal if the Docker container is still running, run
@@ -87,7 +103,7 @@ If you want to open another terminal if the Docker container is still running, r
 docker attach urc_software_container
 ```
 
-## 7. Finish Setup
+## 8. Finish Setup
 
 In its current state, the Docker container is not quite ready for building the `urc-software` codebase. 
 
@@ -104,7 +120,6 @@ git clone https://github.com/RoboJackets/urc-software.git --recursive
 ```bash
 echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bashrc
-echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -118,12 +133,13 @@ rosdep install --from-paths src --ignore-src -r -y
 ### Build
 
 ``` bash
+echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc
 source ~/.bashrc
 cd /colcon_ws
 colcon build
 ```
 
-## 8. Closing the Container
+## 9. Closing the Container
 
 Once you are done with the conatiner, be sure to close the Docker container. Otherwise, the 
 Docker container will take up a big chunk of memory on your computer.
@@ -132,13 +148,13 @@ Important Note: DO NOT delete the Docker container! The container saves its curr
 work is also preserved inside the container as well! Only delete the container if you somehow mess up your
 environment. Then, you can just create a new container from the `robojackets/urc-baseimage` image.
 
-### 8a. Close Docker Conatiner Using VS Code
+### 9a. Close Docker Conatiner Using VS Code
 
 Closing the VS Code window does not stop the Docker container. To stop the Docker container, you can either:
 * go to the `Remote Explorer` tab, right click the active Docker container, and hit `Stop Container`.
 * go to the `Docker` tab, and toggle the green arrow on the active container.
 
-### 8b. Close Docker Container Using Command Line
+### 9b. Close Docker Container Using Command Line
 
 Close the Docker container using
 
@@ -146,13 +162,22 @@ Close the Docker container using
 docker stop urc_software_container
 ```
 
-## 9. Using the GUI
+## 10. Using the GUI
 
 To use the GUI, open your web browser and enter: 
 ```
 http://localhost:8080/vnc.html
 ```
 
-You should get a webpage for noVNC. Click `Connect` and enter the password, `1234`.
+You should get a webpage for noVNC. Click `Connect` and enter the password, `urc-2023`.
 
 After this, you should see a Terminator window. You can launch GUI applications from this window. For example, try launching `gazebo`.
+
+## 11. Deleting the Docker Container
+
+If your development environment gets messed up, you can delete the development environment with:
+```bash
+docker stop urc_software_container
+docker rm urc_software_container
+```
+You can also delete the container in the `Remote Explorer` tab or the `Docker` tab by right clicking on the container and removing it.

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -121,6 +121,7 @@ rosdep install --from-paths src --ignore-src -r -y
 ### Build
 
 ``` bash
+source ~/.bashrc
 cd /colcon_ws
 colcon build
 ```
@@ -152,7 +153,7 @@ docker stop urc_firmware_container
 
 To use the GUI, open your web browser and enter: 
 ```
-localhost:8080
+http://localhost:8080/vnc.html
 ```
 
 You should get a webpage for noVNC. Click `Connect` and enter the password, `1234`.

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -101,10 +101,19 @@ cd /colcon_ws/src
 rm -rf urc-software
 git clone https://github.com/RoboJackets/urc-software.git --recursive
 ```
+
+### bashrc Setup
+
+```bash
+echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bashrc
+echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc
+source ~/.bashrc
+```
+
 ### Update ROS Dependencies
 ```bash
 cd /colcon_ws
-source /opt/ros/humble/setup.bash
 sudo apt-get update
 rosdep update
 rosdep install --from-paths src --ignore-src -r -y

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -1,7 +1,10 @@
 # Docker Installation
 
 Doing a Docker installation is a good method for setting up the repository on any operating system
-that isn't Ubuntu 22.04 LTS. It is a lighter-weight and faster alternative than installing a Virtual Machine. However, this is not a good method if you need to use rviz or gazebo. 
+that isn't Ubuntu 22.04 LTS. It is a lighter-weight and faster alternative than installing a Virtual Machine.
+In addition, you can run GUI applications like gazebo using the VNC server.
+
+Although compiling code in a Docker container is not as fast as compiling it on Ubuntu 22.04 natively, it is not slow by any means. If you use an IDE with Docker support (such as VSCode with the recommended extensions), writing code will be no different than doing it natively on Ubuntu 22.04. Regardless, you need a decent computer, especially if you want the gazebo simulations to run at a decent speed.
 
 ## 1. Install Docker
 
@@ -10,6 +13,12 @@ that isn't Ubuntu 22.04 LTS. It is a lighter-weight and faster alternative than 
 [Mac Instructions](https://docs.docker.com/desktop/mac/install/)
 
 [Ubuntu Instructions](https://docs.docker.com/engine/install/ubuntu/)
+
+To check that everything installed OK, you should be able to open the command line and type:
+```bash
+docker
+```
+
 
 ## 2. Install VSCode (Highly Recommended)
 
@@ -27,28 +36,20 @@ Search for and install the following extensions in VSCode
 * ROS
 * Remote - Containers
 
-## 3. Download Docker Image
+## 3. Create Docker Image
 
-Next, you need to get the Docker image for our repository. You can either manually build the Docker image or you can download the Docker image from Dockerhub.
+You need to obtain the following 2 files:
+* [docker_gui/Dockerfile]()
+* [docker_gui/entrypoint.sh]()
 
-### 3a. Download Image from Dockerhub
+If you do not have `git` installed, you can just click the links above and save the files onto your computer with the same names into a folder somewhere.
 
-We only have an ```amd64``` version on our Dockerhub. If your architecture does not match, then use the manual installation method.
-
-```bash
-docker pull robojackets/urc-baseimage
-```
-
-### 3b. Manually Build Image
-
-To do the manual installation, you need to download the Dockerfile in the `urc-software` repository. If you have `git` installed, you can just clone the whole repository:
+If you have `git` installed, you can just clone the whole repository, then navigate to `docker_gui/`.
 ```bash
 git clone https://github.com/RoboJackets/urc-software.git
-cd urc-software
 ```
-If you don't have `git` or don't want to download the whole repository, you can just save [this](https://raw.githubusercontent.com/RoboJackets/urc-software/master/Dockerfile) as `Dockerfile` on your computer.
 
-Once you are in the same directory as our Dockerfile, run:
+Once you are in the same directory as `docker_gui/Dockerfile` and `docker_gui/entrypoint.sh`, run:
 ```bash
 docker build -t robojackets/urc-baseimage .
 ```
@@ -58,7 +59,7 @@ docker build -t robojackets/urc-baseimage .
 To create a Docker container from the newly created image `robojackets/urc-baseimage`, run
 
 ```bash
-docker container create -i -t --name=urc_software_container robojackets/urc-baseimage
+docker container create -i -t -p=8080:8080 --name=urc_software_container robojackets/urc-baseimage
 ```
 
 ## 5. Launch Docker Container
@@ -71,14 +72,16 @@ First, make sure that you have the `Remote - Containers` extension installed.
 
 Once you have it, click on the Remote Explorer tab. You should see the container you made in the "containers" tab. 
 
-To launch the container in VSCode, right click the container and select `Attach to Container`. This will open VSCode in the Docker container.
+To launch the container in VSCode, either 
+* right click the container and select `Attach to Container`.
+* hover over the container and click on the folder with a plus.
 
 ### 5b. Launch Docker Container Using Command Line
 
-To run a Docker container in the command line, run
+To run the Docker container in the command line, run
 
 ```bash
-docker start -i urc_software_container
+docker start -i -p=8080:8080 urc_software_container
 ```
 
 If you want to open another terminal if the Docker container is still running, run
@@ -112,3 +115,37 @@ rosdep install --from-paths src --ignore-src -r -y
 cd /colcon_ws
 colcon build
 ```
+
+## 7. Closing the Container
+
+Once you are done with the conatiner, be sure to close the Docker container. Otherwise, the 
+Docker container will take up a big chunk of memory on your computer.
+
+Important Note: DO NOT delete the Docker container! The container saves its current state, so all of your
+work is also preserved inside the container as well! Only delete the container if you somehow mess up your
+environment. Then, you can just create a new container from the `robojackets/urc-baseimage` image.
+
+### 7a. Close Docker Conatiner Using VSCode
+
+Closing the VSCode window does not stop the Docker container. To stop the Docker container, you can either:
+* go to the `Remote Explorer` tab, right click the active Docker container, and hit `Stop Container`.
+* go to the `Docker` tab, and toggle the green arrow on the active container.
+
+### 7b. Close Docker Container Using Command Line
+
+Close the Docker container using
+
+```bash
+docker stop urc_firmware_container
+```
+
+## 8. Using the GUI
+
+To use the GUI, open your web browser and enter: 
+```
+localhost:8080
+```
+
+You should get a webpage for noVNC. Click `Connect` and enter the password, `1234`.
+
+After this, you should see a Terminator window. You can launch GUI applications from this window. For example, try launching `gazebo`.

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -81,13 +81,11 @@ You can launch your newly created Docker container using the command line or VS 
 
 ### 7a. Launch Docker Container Using VS Code
 
-First, make sure that you have the `Remote - Containers` extension installed.
+First, double check you have the `Docker` extension installed.
 
-Once you have it, click on the Remote Explorer tab. You should see the container you made in the "containers" tab. 
+Once you have it, click on the Docker tab on the left of the editor. You should see the container you made in the "containers" tab. 
 
-To launch the container in VS Code, either 
-* right click the container and select `Attach to Container`.
-* hover over the container and click on the folder with a plus.
+To launch the container in VS Code, right click it and select `Start`.
 
 ### 7b. Launch Docker Container Using Command Line
 
@@ -151,8 +149,8 @@ environment. Then, you can just create a new container from the `robojackets/urc
 ### 9a. Close Docker Conatiner Using VS Code
 
 Closing the VS Code window does not stop the Docker container. To stop the Docker container, you can either:
-* go to the `Remote Explorer` tab, right click the active Docker container, and hit `Stop Container`.
 * go to the `Docker` tab, and toggle the green arrow on the active container.
+* go to the `Remote Explorer` tab, right click the active Docker container, and hit `Stop Container`.
 
 ### 9b. Close Docker Container Using Command Line
 

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -2,9 +2,9 @@
 
 Doing a Docker installation is a good method for setting up the repository on any operating system
 that isn't Ubuntu 22.04 LTS. It is a lighter-weight and faster alternative than installing a Virtual Machine.
-In addition, you can run GUI applications like gazebo using the VNC server.
+In addition, you can run GUI applications like Gazebo using the VNC server.
 
-Although compiling code in a Docker container is not as fast as compiling it on Ubuntu 22.04 natively, it is not slow by any means. If you use an IDE with Docker support (such as VSCode with the recommended extensions), writing code will be no different than doing it natively on Ubuntu 22.04. Regardless, you need a decent computer, especially if you want the gazebo simulations to run at a decent speed.
+Although compiling code in a Docker container is not as fast as compiling it on Ubuntu 22.04 natively, it is not slow by any means. If you use an IDE with Docker support (such as VS Code with the recommended extensions), writing code will be no different than doing it natively on Ubuntu 22.04. 
 
 ## 1. Install Docker
 
@@ -19,42 +19,39 @@ To check that everything installed OK, you should be able to open the command li
 docker
 ```
 
+## 2. Install VS Code (Highly Recommended)
 
-## 2. Install VSCode (Highly Recommended)
+You do not have to use VS Code. However, VS Code has very nice extensions for using Docker containers.
 
-You do not have to use VSCode. However, VSCode has very nice extensions for using Docker containers.
+[Download VS Code here](https://code.visualstudio.com/Download)
 
-### 2a. Install VSCode
+### 2a. Install VS Code Extensions
 
-[Download VSCode here](https://code.visualstudio.com/Download)
-
-### 2b. Install VSCode Extensions
-
-Search for and install the following extensions in VSCode
+Search for and install the following extensions in VS Code
 
 * Docker
 * ROS
 * Remote - Containers
 
-## 3. Create Docker Image
+## 3. Install Git
 
-You need to obtain the following 2 files:
-* [docker_gui/Dockerfile]()
-* [docker_gui/entrypoint.sh]()
+[Install Git using the instructions here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
-If you do not have `git` installed, you can just click the links above and save the files onto your computer with the same names into a folder somewhere.
 
-If you have `git` installed, you can just clone the whole repository, then navigate to `docker_gui/`.
+## 4. Create Docker Image
+
 ```bash
 git clone https://github.com/RoboJackets/urc-software.git
 ```
 
-Once you are in the same directory as `docker_gui/Dockerfile` and `docker_gui/entrypoint.sh`, run:
+Navigate to the directory `docker_gui` and run:
 ```bash
 docker build -t robojackets/urc-baseimage .
 ```
 
-## 4. Create Docker Container
+Run the command as a superuser if you get permission errors.
+
+## 5. Create Docker Container
 
 To create a Docker container from the newly created image `robojackets/urc-baseimage`, run
 
@@ -62,21 +59,21 @@ To create a Docker container from the newly created image `robojackets/urc-basei
 docker container create -i -t -p=8080:8080 --name=urc_software_container robojackets/urc-baseimage
 ```
 
-## 5. Launch Docker Container
+## 6. Launch Docker Container
 
-You can launch your newly created Docker container using the command line or VSCode.
+You can launch your newly created Docker container using the command line or VS Code.
 
-### 5a. Launch Docker Container Using VSCode
+### 6a. Launch Docker Container Using VS Code
 
 First, make sure that you have the `Remote - Containers` extension installed.
 
 Once you have it, click on the Remote Explorer tab. You should see the container you made in the "containers" tab. 
 
-To launch the container in VSCode, either 
+To launch the container in VS Code, either 
 * right click the container and select `Attach to Container`.
 * hover over the container and click on the folder with a plus.
 
-### 5b. Launch Docker Container Using Command Line
+### 6b. Launch Docker Container Using Command Line
 
 To run the Docker container in the command line, run
 
@@ -90,7 +87,7 @@ If you want to open another terminal if the Docker container is still running, r
 docker attach urc_software_container
 ```
 
-## 6. Finish Setup
+## 7. Finish Setup
 
 In its current state, the Docker container is not quite ready for building the `urc-software` codebase. 
 
@@ -126,7 +123,7 @@ cd /colcon_ws
 colcon build
 ```
 
-## 7. Closing the Container
+## 8. Closing the Container
 
 Once you are done with the conatiner, be sure to close the Docker container. Otherwise, the 
 Docker container will take up a big chunk of memory on your computer.
@@ -135,21 +132,21 @@ Important Note: DO NOT delete the Docker container! The container saves its curr
 work is also preserved inside the container as well! Only delete the container if you somehow mess up your
 environment. Then, you can just create a new container from the `robojackets/urc-baseimage` image.
 
-### 7a. Close Docker Conatiner Using VSCode
+### 8a. Close Docker Conatiner Using VS Code
 
-Closing the VSCode window does not stop the Docker container. To stop the Docker container, you can either:
+Closing the VS Code window does not stop the Docker container. To stop the Docker container, you can either:
 * go to the `Remote Explorer` tab, right click the active Docker container, and hit `Stop Container`.
 * go to the `Docker` tab, and toggle the green arrow on the active container.
 
-### 7b. Close Docker Container Using Command Line
+### 8b. Close Docker Container Using Command Line
 
 Close the Docker container using
 
 ```bash
-docker stop urc_firmware_container
+docker stop urc_software_container
 ```
 
-## 8. Using the GUI
+## 9. Using the GUI
 
 To use the GUI, open your web browser and enter: 
 ```

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -143,7 +143,18 @@ Close the Docker container using
 docker stop urc_software_container
 ```
 
-## 10. Using the GUI
+## 10. Container Password
+
+People outside your LAN should not be able to connect to your VNC server unless the port is being forwarded 
+and the network firewall is disabled. If you want to change the default password, open the Dockerfile and change the line
+
+```bash
+RUN x11vnc -storepasswd urc-2023 ~/.vnc/passwd
+```
+
+by replacing the default password, `urc-2023`.
+
+## 11. Using the GUI
 
 To use the GUI, open your web browser and enter: 
 ```
@@ -154,7 +165,7 @@ You should get a webpage for noVNC. Click `Connect` and enter the password, `urc
 
 After this, you should see a terminal window. You can launch GUI applications from this window. For example, try launching `gazebo` or `rviz2`.
 
-## 11. Deleting the Docker Container
+## 12. Deleting the Docker Container
 
 If your development environment gets messed up, you can delete the development environment with:
 ```bash

--- a/documents/installation/docker_installation.md
+++ b/documents/installation/docker_installation.md
@@ -4,7 +4,7 @@ Doing a Docker installation is a good method for setting up the repository on an
 that isn't Ubuntu 22.04 LTS. It is a lighter-weight and faster alternative than installing a Virtual Machine.
 In addition, you can run GUI applications like Gazebo using the VNC server.
 
-Although compiling code in a Docker container is not as fast as compiling it on Ubuntu 22.04 natively, it is not slow by any means. If you use an IDE with Docker support (such as VS Code with the recommended extensions), writing code will be no different than doing it natively on Ubuntu 22.04. 
+Although compiling code in a Docker container is not as fast as compiling it on Ubuntu 22.04 natively, it is not slow by any means. If you use an IDE with Docker support (such as VSCode with the recommended extensions), writing code will be no different than doing it natively on Ubuntu 22.04. 
 
 ## 1. Install Docker
 
@@ -14,20 +14,20 @@ Although compiling code in a Docker container is not as fast as compiling it on 
 
 [Ubuntu Instructions](https://docs.docker.com/engine/install/ubuntu/)
 
+### NOTE
+* If you are on Linux, add yourself to the `docker` group. Being a member of the `docker` group allows you to run `docker` without `sudo`.
+```bash
+sudo groupadd docker
+sudo usermod -aG docker $USER
+```
+
+After you complete the installation, **restart your computer**!
+
 To check that everything installed OK, you should be able to open the command line and type:
 ```bash
 docker
 ```
 
-### INSTALLATION NOTES:
-* It's probably a good idea to restart your computer once you install Docker.
-* Docker has to be running before you can use it. When you install Docker, it usually enables itself upon the computer turning on. If this isn't the case, be sure to launch Docker before proceeding.
-* For Linux users: I recommed adding youself to the `docker` group. Being a member of the `docker` group allows you to run `docker` without `sudo`. After running the following two commands, log back out and in again for the changes to take affect.
-
-```bash
-sudo groupadd docker
-sudo usermod -aG docker $USER
-```
 
 ## 2. Install VS Code (Highly Recommended)
 
@@ -101,38 +101,20 @@ If you want to open another terminal if the Docker container is still running, r
 docker attach urc_software_container
 ```
 
-## 8. Finish Setup
+## 8. Build!
 
-In its current state, the Docker container is not quite ready for building the `urc-software` codebase. 
-
-### Re-clone `urc-software` in `/colcon_ws/src`
+First, it's always a good idea to check for updates. Nothing will happen if you just created the image. However, if you decide to re-create the container a while after you made the initial image, you will need to update those packages.
 
 ```bash
-cd /colcon_ws/src
-rm -rf urc-software
-git clone https://github.com/RoboJackets/urc-software.git --recursive
-```
-
-### bashrc Setup
-
-```bash
-echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
-echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bashrc
-source ~/.bashrc
-```
-
-### Update ROS Dependencies
-```bash
+sudo apt update
+sudo apt upgrade
 cd /colcon_ws
-sudo apt-get update
 rosdep update
-rosdep install --from-paths src --ignore-src -r -y
 ```
-### Build
+
+Now, its time for the moment of truth!
 
 ``` bash
-echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc
-source ~/.bashrc
 cd /colcon_ws
 colcon build
 ```
@@ -142,9 +124,10 @@ colcon build
 Once you are done with the conatiner, be sure to close the Docker container. Otherwise, the 
 Docker container will take up a big chunk of memory on your computer.
 
-Important Note: DO NOT delete the Docker container! The container saves its current state, so all of your
-work is also preserved inside the container as well! Only delete the container if you somehow mess up your
-environment. Then, you can just create a new container from the `robojackets/urc-baseimage` image.
+Note: Deleting the Docker container is not a big deal, since
+* Your work is stored in a volume, which is seperate from the container.
+* All of the required pacakges were installed in the image creation step.
+However, the container remembers its state, so its a good idea to reuse the same container unless you mess up your environment.
 
 ### 9a. Close Docker Conatiner Using VS Code
 
@@ -169,7 +152,7 @@ http://localhost:8080/vnc.html
 
 You should get a webpage for noVNC. Click `Connect` and enter the password, `urc-2023`.
 
-After this, you should see a Terminator window. You can launch GUI applications from this window. For example, try launching `gazebo`.
+After this, you should see a terminal window. You can launch GUI applications from this window. For example, try launching `gazebo` or `rviz2`.
 
 ## 11. Deleting the Docker Container
 


### PR DESCRIPTION
# Description
This PR does the following:
- Adds another Dockerfile in docker_gui. 
- Docker container can now run gui apps like gazebo

Fixes #46 

# Testing Steps 
1. Follow the Docker installation instructions. Ensure that no errors occur, and build the code.
2. Try running different gui apps.

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
