### PR TITLE
Automated Ubuntu install script

### DIFF
--- a/documents/installation/ubuntu_installation.md
+++ b/documents/installation/ubuntu_installation.md
@@ -27,6 +27,6 @@ cd urc-software/
 ### Getting errors when running colcon build?
 If you have an error when running colcon build or rosdep:
 - Search the apt repository for the appropriate ROS package (usually ros-humble-package-name, using em dashes, with the package name being the package that caused an ament_cmake error)
-- If it exists, install it using `apt installros-humble-package-name`
+- If it exists, install it using `apt install ros-humble-package-name`
 - Run colcon build using `colcon build --symlink-install`
 - Repeat as neccessary until build succeeds

--- a/documents/installation/ubuntu_installation.md
+++ b/documents/installation/ubuntu_installation.md
@@ -2,54 +2,7 @@
 
 ## 1. Make sure you are running Ubuntu 22.04!
 
-## 2. Install ROS2
-
-```bash
-sudo apt install software-properties-common
-```
-```bash
-sudo add-apt-repository universe
-```
-```bash
-sudo apt update && sudo apt install curl gnupg lsb-release
-sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-```
-```bash
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-```
-```bash
-sudo apt update
-```
-```bash
-sudo apt upgrade
-```
-```bash
-sudo apt install ros-humble-desktop-full
-```
-
-## 3. Install Colcon
-   
-```bash
-sudo apt install python3-colcon-common-extensions
-```
-
-## 4. bashrc Setup
-
-```bash
-echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
-```
-```bash
-echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> ~/.bashrc
-```
-```bash
-echo "source /usr/share/gazebo/setup.sh" >> ~/.bashrc
-```
-```bash
-source ~/.bashrc
-```
-
-## 5. Create a colcon environment
-
+## 2. Create a folder to contain the urc-software repo
 ```bash
 cd <path to where you want to keep the project>
 ```
@@ -57,32 +10,23 @@ cd <path to where you want to keep the project>
 mkdir -p colcon-urc/src
 ```
 
-## 6. Clone the repository into the colcon environment
+## 3. Clone the urc-software git repository 
 ```bash
 cd colcon-urc/src
 ```
 ```bash
 git clone https://github.com/RoboJackets/urc-software.git --recursive
 ```
+## 4. Run the automated install script
+This will install ROS2 and its associated system packages, including initializing rosdep and building our workspace.
 
-## 7. Build your workspace
 ```bash
-cd ..
+cd urc-software/
+./install_script.sh
 ```
-```bash
-colcon build --symlink-install
-```
-
-## 8. Source your environment
-```bash
-. install/setup.bash
-```
-
-## 9. Install and run rosdep
- Make sure to call the 'rosdep install' command from the colcon workspace directory (/colcon-urc)!
-```bash
-sudo apt install python3-rosdep
-sudo rosdep init
-rosdep update
-rosdep install --from-paths src --ignore-src -r -y
-```
+### Getting errors when running colcon build?
+If you have an error when running colcon build or rosdep:
+- Search the apt repository for the appropriate ROS package (usually ros-humble-package-name, using em dashes, with the package name being the package that caused an ament_cmake error)
+- If it exists, install it using `apt installros-humble-package-name`
+- Run colcon build using `colcon build --symlink-install`
+- Repeat as neccessary until build succeeds

--- a/documents/installation/ubuntu_installation.md
+++ b/documents/installation/ubuntu_installation.md
@@ -26,7 +26,8 @@ cd urc-software/
 ```
 ### Getting errors when running colcon build?
 If you have an error when running colcon build or rosdep:
-- Search the apt repository for the appropriate ROS package (usually ros-humble-package-name, using em dashes, with the package name being the package that caused an ament_cmake error) using `apt search ros-humble-package-name`
-- If it exists, install it using `apt install ros-humble-package-name`
+- Search the apt repository for the appropriate ROS package (usually ros-humble-package-name, using em dashes, with the package name being the package that caused an ament_cmake error) using `apt search ros-humble-package-name` or `apt search package-name`
+- Add the package to the list of apt packages to install in the install_script.sh script (line 32)
+- Run the install script with the new packaged added or manually install the package using `apt install ros-humble-package-name`
 - Run colcon build using `colcon build --symlink-install`
 - Repeat as neccessary until build succeeds

--- a/documents/installation/ubuntu_installation.md
+++ b/documents/installation/ubuntu_installation.md
@@ -26,7 +26,7 @@ cd urc-software/
 ```
 ### Getting errors when running colcon build?
 If you have an error when running colcon build or rosdep:
-- Search the apt repository for the appropriate ROS package (usually ros-humble-package-name, using em dashes, with the package name being the package that caused an ament_cmake error)
+- Search the apt repository for the appropriate ROS package (usually ros-humble-package-name, using em dashes, with the package name being the package that caused an ament_cmake error) using `apt search ros-humble-package-name`
 - If it exists, install it using `apt install ros-humble-package-name`
 - Run colcon build using `colcon build --symlink-install`
 - Repeat as neccessary until build succeeds

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-rosdep update
-rosdep install -iy --from-paths ../../src

--- a/install_script.sh
+++ b/install_script.sh
@@ -24,8 +24,17 @@ echo "Updating and upgrading system packages..."
 apt update
 apt upgrade
 
+echo "Installing Python dependencies..."
+apt install pip
+
 echo "Installing ROS2..."
 apt install ros-humble-desktop-full
+
+echo "Installing ROS packages..."
+for package in ros-humble-rosbridge-server nanopb
+do
+	apt install $package
+done
 
 apt install python3-colcon-common-extensions
 
@@ -46,17 +55,22 @@ source /opt/ros/humble/setup.bash
 # - Run the script again
 # - Repeat as neccessary
 
+cd ../
 colcon build --symlink-install
 
 # This script will initialize and run rosdep if in the correct directory
 apt install python3-rosdep
-if ($pwd | grep "src"); then
-		source ../../install/setup.bash
-else
-		source ./install/setup.bash 
-fi
+
 if !(ls /etc/ros/rosdep | grep "sources"); then 
 		rosdep init
 fi
+
 rosdep update
-rosdep install --from-paths ../../src --ignore-src -r -y -v
+
+if ($pwd | grep "src"); then
+		source ../../install/setup.bash
+		rosdep install --from-paths ../../src --ignore-src -r -y -v
+else
+		source ./install/setup.bash 
+		rosdep install --from-paths ./src --ignore-src -r -y -v
+fi

--- a/install_script.sh
+++ b/install_script.sh
@@ -31,10 +31,13 @@ echo "Installing ROS2..."
 apt install ros-humble-desktop-full
 
 echo "Installing ROS packages..."
-for package in ros-humble-rosbridge-server nanopb
+for package in ros-humble-rosbridge-server nanopb ros-humble-robot-localization
 do
 	apt install $package
 done
+
+python3 -m venv venv
+source /venv/bin/activate
 
 apt install python3-colcon-common-extensions
 
@@ -55,9 +58,6 @@ source /opt/ros/humble/setup.bash
 # - Run the script again
 # - Repeat as neccessary
 
-cd ../
-colcon build --symlink-install
-
 # This script will initialize and run rosdep if in the correct directory
 apt install python3-rosdep
 
@@ -66,11 +66,9 @@ if !(ls /etc/ros/rosdep | grep "sources"); then
 fi
 
 rosdep update
+cd ..
 
-if ($pwd | grep "src"); then
-		source ../../install/setup.bash
-		rosdep install --from-paths ../../src --ignore-src -r -y -v
-else
-		source ./install/setup.bash 
-		rosdep install --from-paths ./src --ignore-src -r -y -v
-fi
+source src/install/setup.bash 
+rosdep install --from-paths ./src --ignore-src -r -y -v
+
+colcon build --symlink-install

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,7 +1,5 @@
 #!/bin/bash 
 
-# Note: You should run this script in your colcon workspace folder... if you're in the src folder, it will go up a directory to the workspace
-
 # Become root so we don't have to add sudo to everything
 if [ $UID -ne 0 ]; then
 	echo "-- Becoming root"
@@ -36,8 +34,8 @@ do
 	apt install $package
 done
 
-python3 -m venv venv
-source /venv/bin/activate
+#python3 -m venv venv
+#source /venv/bin/activate
 
 apt install python3-colcon-common-extensions
 
@@ -66,7 +64,7 @@ if !(ls /etc/ros/rosdep | grep "sources"); then
 fi
 
 rosdep update
-cd ..
+cd ../..
 
 source src/install/setup.bash 
 rosdep install --from-paths ./src --ignore-src -r -y -v

--- a/install_script.sh
+++ b/install_script.sh
@@ -31,7 +31,7 @@ echo "Installing ROS2..."
 apt install ros-humble-desktop-full
 
 echo "Installing ROS packages..."
-for package in ros-humble-rosbridge-server nanopb ros-humble-robot-localization
+for package in ros-humble-rosbridge-server nanopb ros-humble-robot-localization ros-humble-velodyne-simulator
 do
 	apt install $package
 done

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,0 +1,62 @@
+#!/bin/bash 
+
+# Note: You should run this script in your colcon workspace folder... if you're in the src folder, it will go up a directory to the workspace
+
+# Become root so we don't have to add sudo to everything
+if [ $UID -ne 0 ]; then
+	echo "-- Becoming root"
+	# Executes the current script as user 0 (sudo)
+	exec sudo $0 $@
+fi
+
+echo "Adding ROS2 keys..."
+apt install software-properties-common
+
+add-apt-repository universe
+
+# Add the ROS GPG key
+apt update && apt install curl gnupg lsb-release
+curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+echo "Updating and upgrading system packages..."
+apt update
+apt upgrade
+
+echo "Installing ROS2..."
+apt install ros-humble-desktop-full
+
+apt install python3-colcon-common-extensions
+
+for line in /opt/ros/humble/setup.bash /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash /usr/share/gazebo/setup.sh 
+do
+		if  grep $line ~/.bashrc 
+then
+		echo $line already added to ~./bashrc
+else
+		echo $line >> ~/.bashrc
+		fi
+done
+
+source /opt/ros/humble/setup.bash
+# If you have an error when running colcon build or rosdep:
+# - Search the apt repository for the appropriate ROS package (usually ros-humble-package-name, using em dashes)
+# - If it exists, install it
+# - Run the script again
+# - Repeat as neccessary
+# TODO: Autoinstall system packages in this script that aremissing from rosdep?
+
+colcon build --symlink-install
+
+# This script will initialize and run rosdep if in the correct directory
+apt install python3-rosdep
+if [$pwd | grep "src"]; then
+		source ../../install/setup.bash
+else
+		source ./install/setup.bash 
+fi
+
+rosdep init
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y -v

--- a/install_script.sh
+++ b/install_script.sh
@@ -45,7 +45,6 @@ source /opt/ros/humble/setup.bash
 # - If it exists, install it
 # - Run the script again
 # - Repeat as neccessary
-# TODO: Autoinstall system packages in this script that aremissing from rosdep?
 
 colcon build --symlink-install
 
@@ -56,9 +55,8 @@ if ($pwd | grep "src"); then
 else
 		source ./install/setup.bash 
 fi
-
 if !(ls /etc/ros/rosdep | grep "sources"); then 
 		rosdep init
 fi
 rosdep update
-rosdep install --from-paths src --ignore-src -r -y -v
+rosdep install --from-paths ../../src --ignore-src -r -y -v

--- a/install_script.sh
+++ b/install_script.sh
@@ -51,12 +51,14 @@ colcon build --symlink-install
 
 # This script will initialize and run rosdep if in the correct directory
 apt install python3-rosdep
-if [$pwd | grep "src"]; then
+if ($pwd | grep "src"); then
 		source ../../install/setup.bash
 else
 		source ./install/setup.bash 
 fi
 
-rosdep init
+if !(ls /etc/ros/rosdep | grep "sources"); then 
+		rosdep init
+fi
 rosdep update
 rosdep install --from-paths src --ignore-src -r -y -v


### PR DESCRIPTION
# Description
New install instructions for Ubuntu users including automated Bash script that will run required install commands (ROS2, rosdep, ect.)

Fixes [issue 75](https://github.com/RoboJackets/urc-software/issues/75)

# Testing Steps
1. Follow along with the updated Ubuntu installation instructions

Expectation: The script should run and our ROS packages should build without errors

# Self Checklist
- [x] I have tested that the new behavior works
