### PR TITLE
bug/remove_ensure_submodule_warning

### DIFF
--- a/cmake/default_settings.cmake
+++ b/cmake/default_settings.cmake
@@ -15,7 +15,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # Check submodules
-set(GIT_REPO_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(GIT_REPO_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
 include(${CMAKE_CURRENT_LIST_DIR}/ensure_submodules.cmake)
 
 # Add color for ninja generator


### PR DESCRIPTION
# Description
Fixes the cmake warning that prints when building, such as:

```
CMake Warning at /__w/urc-software/urc-software/colcon_ws/src/urc-software/cmake/ensure_submodules.cmake:34 (message):
  Couldn't find .git folder in external package external/nanopb/.git ...
Call Stack (most recent call first):
  /__w/urc-software/urc-software/colcon_ws/src/urc-software/cmake/default_settings.cmake:19 (include)
  CMakeLists.txt:4 (include)
```

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
