### PR TITLE
Adds basic camera node

### DIFF
--- a/urc_platform/CMakeLists.txt
+++ b/urc_platform/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(urc_nanopb REQUIRED)
 find_package(urc_util REQUIRED)
+find_package(usb_cam REQUIRED)
 
 include_directories(
   include
@@ -34,6 +35,7 @@ set(dependencies
   diagnostic_updater
   urc_nanopb
   urc_util
+  usb_cam
 )
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/urc_platform/config/camera_params.yaml
+++ b/urc_platform/config/camera_params.yaml
@@ -1,0 +1,11 @@
+camera:
+  ros__parameters:
+    video_device: "/dev/cam"
+    image_width: 640
+    image_height: 480
+    pixel_format: "mjepg"
+    io_method: "mmap"
+    camera_frame_id: "camera"
+    framerate: 30
+    camera_info_url: ""
+    camera_name: ""

--- a/urc_platform/launch/camera.launch.py
+++ b/urc_platform/launch/camera.launch.py
@@ -12,11 +12,11 @@ def generate_launch_description():
     # ~<camera_name>/image_raw/compressed
     camera_node = Node(
             package='usb_cam',
-            executable='usb_cam_node',
+            executable='usb_cam_node_exe',
             output='screen',
             parameters=[
                 PathJoinSubstitution([FindPackageShare('urc_platform'), 'config',
-                                     'camera.yaml'])
+                                     'camera_params.yaml'])
             ]
         )
 

--- a/urc_platform/launch/camera.launch.py
+++ b/urc_platform/launch/camera.launch.py
@@ -1,0 +1,25 @@
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    # this node should produce both a uncompressed and compressed version of the image
+    # pub topics:
+    # ~<camera_name>/image_raw
+    # ~<camera_name>/image_raw/compressed
+    camera_node = Node(
+            package='usb_cam',
+            executable='usb_cam_node',
+            output='screen',
+            parameters=[
+                PathJoinSubstitution([FindPackageShare('urc_platform'), 'config',
+                                     'camera.yaml'])
+            ]
+        )
+
+    return LaunchDescription([
+        camera_node
+    ])

--- a/urc_platform/package.xml
+++ b/urc_platform/package.xml
@@ -18,6 +18,9 @@
   <depend>sensor_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>urc_nanopb</depend>
+  <depend>usb_cam</depend>
+  <depend>image_transport</depend>
+  <depend>image_transport_plugins</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# Description
Adds a launch file that  uses the usb_cam library to produce a raw and compressed image topic.

# Testing Steps
* Modify the `camera_params.yaml` file so that the `video_device` parameter is set to a camera device.
* Run the launch file
* Run `rqt`
* View the image topics

# Self Checklist
- [ ] I have formatted my code using `ament_uncrustify --reformat`
- [ ] I have tested that the new behavior works 
