### PR TITLE
Feature: D435i Depth Camera IMU Fusion

### DIFF
--- a/urc_perception/launch/d435i.launch.py
+++ b/urc_perception/launch/d435i.launch.py
@@ -1,0 +1,43 @@
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch.actions import IncludeLaunchDescription, GroupAction
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import SetRemap, Node, SetParameter
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+
+def generate_launch_description():
+    realsense = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("realsense2_camera"),
+                        "launch", "rs_launch.py"
+                    ]
+                )
+            ],
+        ),
+        launch_arguments={
+            "unite_imu_method": "2",
+            "enable_accel": "true",
+            "enable_gyro": "true"
+        }.items()
+    )
+
+    imu_fusion = Node(
+        package="imu_complementary_filter",
+        executable="complementary_filter_node"
+    )
+
+    return LaunchDescription([
+        GroupAction([
+            SetRemap(src='/camera/imu', dst='/imu/data_raw'),
+            realsense,
+        ]),
+        GroupAction([
+            SetParameter(name="publish_tf", value="true"),
+            imu_fusion,
+        ])
+
+    ])

--- a/urc_perception/package.xml
+++ b/urc_perception/package.xml
@@ -25,6 +25,7 @@
   <depend>librealsense2</depend>
   <depend>navigation2</depend>
   <depend>nav2_costmap_2d</depend>
+  <depend>imu_tools</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# Description
This PR does the following:
- Enable imu fusion for d435i depth camera

Expectation: output fused imu data under /imu/data in sensor/msg/Imu type

# Launch Procedure

`ros2 launch urc_perception d435i.launch.py`

