### PR TITLE
Set submodule for aruco_ros to forked repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,5 @@
 	branch = humble
 [submodule "external/aruco_ros"]
 	path = external/aruco_ros
-	url = https://github.com/pal-robotics/aruco_ros.git
+	url = https://github.com/yambati03/aruco_ros.git
+	branch = humble-devel


### PR DESCRIPTION
# Description
This PR updates the submodule for `aruco_ros` to a forked repo that includes changes to remap the topics to those published to by the realsense node.

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
