### PR TITLE
Added gyro data

### DIFF
--- a/urc_imu/package.xml
+++ b/urc_imu/package.xml
@@ -12,6 +12,7 @@
     <author email="eric@ericperko.com">Eric Perko</author>
     <author>Steven Martin</author>
     <exec_depend>geometry_msgs</exec_depend>
+    <exec_depend>std_msgs</exec_depend>
     <exec_depend>nmea_msgs</exec_depend>
     <exec_depend>rclpy</exec_depend>
     <exec_depend>sensor_msgs</exec_depend>

--- a/urc_imu/src/libimu_driver/driver.py
+++ b/urc_imu/src/libimu_driver/driver.py
@@ -1,5 +1,6 @@
 from rclpy.node import Node
 from sensor_msgs.msg import Imu
+from std_msgs.msg import Int32
 from libimu_driver.checksum_utils import check_imu_checksum
 import re
 
@@ -9,6 +10,7 @@ class Ros2IMUDriver(Node):
         super().__init__('imu_driver')
 
         self.imu_pub = self.create_publisher(Imu, '/imu', 10)
+        self.yaw_pub = self.create_publisher(Int32, '/yaw', 10)
 
     # Returns True if we successfully did something with the passed in
     def add_sentence(self, imu_string, frame_id, timestamp=None):
@@ -19,17 +21,24 @@ class Ros2IMUDriver(Node):
             return False
 
         self.get_logger().info("Sentence received: %s" % imu_string)
-        things = re.findall(r"-?[0-9]?[0-9]\.[0-9][0-9]", str(imu_string))
+        things = re.findall(r"-?[0-9]?[0-9]?[0-9]\.[0-9][0-9]", str(imu_string))
         current_imu = Imu()
+        current_yaw = Int32()
         current_imu.orientation.x = float(things[0])
         current_imu.orientation.y = float(things[1])
         current_imu.orientation.z = float(things[2])
         current_imu.orientation.w = float(things[3])
-        current_imu.angular_velocity.x = float(things[4])
+        current_yaw.data = int(float(things[4]))
         current_imu.linear_acceleration.x = float(things[5])
         current_imu.linear_acceleration.y = float(things[6])
         current_imu.linear_acceleration.z = float(things[7])
+        current_imu.angular_velocity.x = float(things[8])
+        current_imu.angular_velocity.y = float(things[9])
+        current_imu.angular_velocity.z = float(things[10])
+        if len(things) > 11:
+            print("Too many items received in IMU driver message!")
         self.imu_pub.publish(current_imu)
+        self.yaw_pub.publish(current_yaw)
 
         return True
 


### PR DESCRIPTION
# Description
This PR does the following:
- Adds gyro data to the IMU
-  Separated yaw value into a new topic (/yaw) for debugging


# Testing Steps (if relevant)
## Test Case 1
1. `colcon build`
2. `. install/setup.bash`
3. `ros2 launch imu_driver imu_serial_driver.launch.py`

Expectation: Should publish a sensor_msgs/msg/Imu message to /imu and a yaw (std_msgs/msg/Int32) message to /yaw.


# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
