### PR TITLE
Quick fixes

### DIFF
--- a/urc_hw_description/urdf/ros2_control.xacro
+++ b/urc_hw_description/urdf/ros2_control.xacro
@@ -176,7 +176,7 @@
       <ros2_control name="rover_drivetrain" type="system">
         <hardware>
           <plugin>urc_hw/RoverDrivetrain</plugin>
-          <param name="udp_address">192.168.1.90</param>
+          <param name="udp_address">192.168.1.113</param>
           <param name="udp_port">8443</param>
         </hardware>
         <joint name="left_wheel">
@@ -257,7 +257,6 @@
 
 
 </robot>
-
 
 
 

--- a/urc_platform/include/motor_controller.hpp
+++ b/urc_platform/include/motor_controller.hpp
@@ -56,7 +56,7 @@ public:
   rclcpp::TimerBase::SharedPtr timer_;
   double publish_encoder_ticks_frequency_;
 
-  const int ENCODER_CPR = 6144;
+  const int ENCODER_CPR = 2048;
   const float WHEEL_RADIUS = 0.170;
   const float VEL_TO_COUNTS_FACTOR = ENCODER_CPR / (2 * M_PI * WHEEL_RADIUS);
   const int QPPR = 15562;


### PR DESCRIPTION
This is a very quick PR to ensure that changes made in hardware testing make it to master. This means:
* Changing the IP address of the Teensy for the rover drivetrain controller.
* Changing the CPR for the motor controller from 6144 to 2048 to lower sensitivity to input for the drivetrain.
