### PR TITLE
[hardware] GPS config and drivetrain config

### DIFF
--- a/urc_bringup/config/controller_config.yaml
+++ b/urc_bringup/config/controller_config.yaml
@@ -48,9 +48,9 @@ rover_drivetrain_controller:
     left_wheel_names: ["left_wheel"]
     right_wheel_names: ["right_wheel"]
 
-    wheel_separation: 0.50
+    wheel_separation: 0.78
     #wheels_per_side: 1  # actually 2, but both are controlled by 1 signal
-    wheel_radius: 0.20
+    wheel_radius: 0.12
 
     wheel_separation_multiplier: 1.0
     left_wheel_radius_multiplier: 1.0
@@ -75,8 +75,8 @@ rover_drivetrain_controller:
     linear.x.has_velocity_limits: true
     linear.x.has_acceleration_limits: true
     linear.x.has_jerk_limits: false
-    linear.x.max_velocity: 2.5
-    linear.x.min_velocity: -2.5
+    linear.x.max_velocity: 1.0
+    linear.x.min_velocity: -1.0
     linear.x.max_acceleration: 2.5
     linear.x.max_jerk: 0.0
     linear.x.min_jerk: 0.0

--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -42,6 +42,7 @@ def generate_launch_description():
         xacro_file, mappings={"use_simulation": "false"}
     )
     robot_desc = robot_description_config.toxml()
+    gps_config = os.path.join(get_package_share_directory("urc_bringup"), "config", "nmea_serial_driver.yaml")
 
     control_node = Node(
         package="controller_manager",
@@ -104,6 +105,12 @@ def generate_launch_description():
             )
         )
     )
+
+    launch_gps = Node(
+        package='nmea_navsat_driver',
+        executable='nmea_serial_driver',
+        output='screen',
+        parameters=[gps_config])
 
     launch_imu = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(

--- a/urc_hw/include/urc_hw/hardware_interfaces/rover_drivetrain.hpp
+++ b/urc_hw/include/urc_hw/hardware_interfaces/rover_drivetrain.hpp
@@ -48,7 +48,7 @@ private:
   // basic info
   const std::string hardware_interface_name;
   double publish_encoder_ticks_frequency_;
-  static constexpr int ENCODER_CPR = 2048;
+  static constexpr int ENCODER_CPR = 42 * 4;
   static constexpr float WHEEL_RADIUS = 0.170;
   static constexpr float VEL_TO_COUNTS_FACTOR = ENCODER_CPR / (2 * M_PI * WHEEL_RADIUS);
   static constexpr int QPPR = 15562;

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -112,9 +112,9 @@ hardware_interface::return_type RoverDrivetrain::read(
   const rclcpp::Time &,
   const rclcpp::Duration &)
 {
-  RCLCPP_INFO(
-    rclcpp::get_logger(
-      "test"), "%.5f, %.5f", velocity_rps_commands[0], velocity_rps_commands[1]);
+  // RCLCPP_INFO(
+  //  rclcpp::get_logger(
+  //      "test"), "%.5f, %.5f", velocity_rps_commands[0], velocity_rps_commands[1]);
 
   return hardware_interface::return_type::OK;
 }


### PR DESCRIPTION
# Description
This PR does the following:
- Fixes GPS driver to use the right config file
- Fixes some params related to drivetrain

# Testing Steps (if relevant)
## Test Case 1
1. colcon build ; . install/setup.bash
2. ros2 launch urc_bringup bringup.launch.py
3. ros2 topic echo /fix


# Self Checklist
- [ ] I have formatted my code using `ament_uncrustify --reformat`
- [ ] I have tested that the new behavior works 
