### PR TITLE
[hw] refactor status light

### DIFF
--- a/urc_bringup/launch/bt.launch.py
+++ b/urc_bringup/launch/bt.launch.py
@@ -15,7 +15,7 @@ def generate_launch_description():
         "libbt_call_trigger.so",
         "libbt_follow_path.so",
         "libbt_update_current_pose.so",
-        "libbt_status_light_publisher.so"
+        "libbt_status_light_publisher.so",
     ]
     node_lib_path_base = os.path.join(
         Path(get_package_share_directory("urc_bt_nodes")).parent.parent.absolute(),
@@ -28,7 +28,7 @@ def generate_launch_description():
     ros_lib_paths = [
         os.path.join(node_lib_path_base, lib_name) for lib_name in ros_lib_names
     ]
-    bt_file_name = "bt_test.xml"
+    bt_file_name = "status_light.xml"
 
     enable_color = SetEnvironmentVariable(name="RCUTILS_COLORIZED_OUTPUT", value="1")
 

--- a/urc_bringup/launch/test_status_light.launch.py
+++ b/urc_bringup/launch/test_status_light.launch.py
@@ -1,0 +1,56 @@
+import os
+from xacro import process_file
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+from launch.actions import IncludeLaunchDescription, RegisterEventHandler
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.event_handlers import OnProcessExit
+
+
+def generate_launch_description():
+    pkg_urc_bringup = get_package_share_directory("urc_bringup")
+
+    controller_config_file_dir = os.path.join(
+        pkg_urc_bringup, "config", "controller_config.yaml"
+    )
+    xacro_file = os.path.join(
+        get_package_share_directory("urc_hw_description"), "urdf/walli.xacro"
+    )
+    assert os.path.exists(xacro_file), "urdf path doesnt exist in " + str(xacro_file)
+    robot_description_config = process_file(
+        xacro_file, mappings={"use_simulation": "false"}
+    )
+    robot_desc = robot_description_config.toxml()
+
+    control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[controller_config_file_dir, {"robot_description": robot_desc}],
+        output="both",
+    )
+
+    load_status_light_controller = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["-p", controller_config_file_dir, "status_light_controller"],
+    )
+
+    bt_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_urc_bringup, "launch", "bt.launch.py")
+        )
+    )
+
+    return LaunchDescription(
+        [
+            control_node,
+            load_status_light_controller,
+            RegisterEventHandler(
+                event_handler=OnProcessExit(
+                    target_action=load_status_light_controller,
+                    on_exit=[bt_launch],
+                )
+            ),
+        ]
+    )

--- a/urc_bringup/strategies/bt_test.xml
+++ b/urc_bringup/strategies/bt_test.xml
@@ -7,8 +7,6 @@
           <LogInfo logger="{ros_log}"
                    message="Trying to Plan Path..."/>
         </Delay>
-        <StatusLightPublisher topic_name="/cmd_statuslight_color" value="1"/>
-        <StatusLightPublisher topic_name="/cmd_statuslight_display" value="1"/>
         <KeepRunningUntilFailure>
           <Inverter>
             <Sequence>
@@ -51,11 +49,6 @@
                   default="&quot;urc_bt&quot;">Logger to use.</input_port>
       <input_port name="message"
                   default="&quot;Replace this with the true message.&quot;">Message to log.</input_port>
-    </Action>
-    <Action ID="StatusLightPublisher"
-            editable="true">
-      <input_port name="topic_name"/>
-      <input_port name="value"/>
     </Action>
     <Action ID="UpdateCurrentPose"
             editable="true">

--- a/urc_bringup/strategies/status_light.xml
+++ b/urc_bringup/strategies/status_light.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root BTCPP_format="4">
+  <BehaviorTree ID="test_status_light">
+    <RunOnce then_skip="true">
+      <Sequence>
+        <Delay delay_msec="100">
+          <StatusLightPublisher topic_name="/command/status_light"
+                                color="red"
+                                state="blink"/>
+        </Delay>
+        <Delay delay_msec="100">
+          <StatusLightPublisher topic_name="/command/status_light"
+                                color="red"
+                                state="off"/>
+        </Delay>
+        <Delay delay_msec="100">
+          <StatusLightPublisher topic_name="/command/status_light"
+                                color="green"
+                                state="blink"/>
+        </Delay>
+        <Delay delay_msec="100">
+          <StatusLightPublisher topic_name="/command/status_light"
+                                color="green"
+                                state="off"/>
+        </Delay>
+        <Delay delay_msec="100">
+          <StatusLightPublisher topic_name="/command/status_light"
+                                color="blue"
+                                state="blink"/>
+        </Delay>
+        <Delay delay_msec="100">
+          <StatusLightPublisher topic_name="/command/status_light"
+                                color="blue"
+                                state="off"/>
+        </Delay>
+      </Sequence>
+    </RunOnce>
+  </BehaviorTree>
+
+  <!-- Description of Node Models (used by Groot) -->
+  <TreeNodesModel>
+    <Action ID="StatusLightPublisher"
+            editable="true">
+      <input_port name="topic_name"
+                  default="/command/status_light"/>
+      <input_port name="color"/>
+      <input_port name="state"/>
+    </Action>
+  </TreeNodesModel>
+
+</root>

--- a/urc_bringup/strategies/urc_strategies.btproj
+++ b/urc_bringup/strategies/urc_strategies.btproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <root BTCPP_format="4" project_name="URC_Strategies">
     <include path="bt_test.xml"/>
+    <include path="status_light.xml"/>
     <include path="test_strategy.xml"/>
     <!-- Description of Node Models (used by Groot) -->
     <TreeNodesModel>
@@ -35,8 +36,9 @@
         <Action ID="RecoverFromSingularity" editable="true"/>
         <Action ID="ServoArm" editable="true"/>
         <Action ID="StatusLightPublisher" editable="true">
-            <input_port name="topic_name"/>
-            <input_port name="value"/>
+            <input_port name="topic_name" default="/command/status_light"/>
+            <input_port name="color"/>
+            <input_port name="state"/>
         </Action>
         <Action ID="UpdateCurrentPose" editable="true">
             <input_port name="topic_name"/>

--- a/urc_bt_nodes/include/urc_bt_nodes/actions/status_light_publisher.hpp
+++ b/urc_bt_nodes/include/urc_bt_nodes/actions/status_light_publisher.hpp
@@ -1,35 +1,72 @@
 #ifndef STATUS_LIGHT_PUBLISHER_HPP__
 #define STATUS_LIGHT_PUBLISHER_HPP__
 
+#include <string>
+
 #include "behaviortree_cpp/basic_types.h"
 #include "behaviortree_cpp/tree_node.h"
 #include "behaviortree_cpp/tree_node.h"
 #include "behaviortree_ros2/ros_node_params.hpp"
 #include "behaviortree_ros2/bt_topic_pub_node.hpp"
-#include "string"
-#include "std_msgs/msg/int8.hpp"
+
+#include "urc_msgs/msg/status_light_command.hpp"
 
 namespace behavior::actions
 {
-class StatusLightPublisher : public BT::RosTopicPubNode<std_msgs::msg::Int8>
-{
-public:
-  StatusLightPublisher(
-    const std::string & instance_name, const BT::NodeConfig & conf,
-    const BT::RosNodeParams & params)
-  : BT::RosTopicPubNode<std_msgs::msg::Int8>(instance_name, conf, params) {}
 
-  static BT::PortsList providedPorts()
+  int stringToColor(std::string color)
   {
-    return providedBasicPorts(
-      {
-        BT::InputPort<std_msgs::msg::Int8>("value"),
-      });
+    if (color == "red")
+    {
+      return urc_msgs::msg::StatusLightCommand::RED;
+    }
+    if (color == "green")
+    {
+      return urc_msgs::msg::StatusLightCommand::GREEN;
+    }
+    if (color == "blue")
+    {
+      return urc_msgs::msg::StatusLightCommand::BLUE;
+    }
+
+    throw std::invalid_argument("Invalid color!");
   }
 
-  bool setMessage(std_msgs::msg::Int8 & msg) override;
+  int stringToState(std::string state)
+  {
+    if (state == "on")
+    {
+      return urc_msgs::msg::StatusLightCommand::ON;
+    }
+    if (state == "off")
+    {
+      return urc_msgs::msg::StatusLightCommand::OFF;
+    }
+    if (state == "blink")
+    {
+      return urc_msgs::msg::StatusLightCommand::BLINK;
+    }
 
-};
+    throw std::invalid_argument("Invalid state!");
+  }
+
+  class StatusLightPublisher : public BT::RosTopicPubNode<urc_msgs::msg::StatusLightCommand>
+  {
+  public:
+    StatusLightPublisher(
+        const std::string &instance_name, const BT::NodeConfig &conf,
+        const BT::RosNodeParams &params)
+        : BT::RosTopicPubNode<urc_msgs::msg::StatusLightCommand>(instance_name, conf, params) {}
+
+    static BT::PortsList providedPorts()
+    {
+      return providedBasicPorts(
+          {BT::InputPort<std::string>("color"),
+           BT::InputPort<std::string>("state")});
+    }
+
+    bool setMessage(urc_msgs::msg::StatusLightCommand &msg) override;
+  };
 }
 
 #endif

--- a/urc_bt_nodes/include/urc_bt_nodes/actions/status_light_publisher.hpp
+++ b/urc_bt_nodes/include/urc_bt_nodes/actions/status_light_publisher.hpp
@@ -14,59 +14,53 @@
 namespace behavior::actions
 {
 
-  int stringToColor(std::string color)
-  {
-    if (color == "red")
-    {
-      return urc_msgs::msg::StatusLightCommand::RED;
-    }
-    if (color == "green")
-    {
-      return urc_msgs::msg::StatusLightCommand::GREEN;
-    }
-    if (color == "blue")
-    {
-      return urc_msgs::msg::StatusLightCommand::BLUE;
-    }
-
-    throw std::invalid_argument("Invalid color!");
+int stringToColor(std::string color)
+{
+  if (color == "red") {
+    return urc_msgs::msg::StatusLightCommand::RED;
+  }
+  if (color == "green") {
+    return urc_msgs::msg::StatusLightCommand::GREEN;
+  }
+  if (color == "blue") {
+    return urc_msgs::msg::StatusLightCommand::BLUE;
   }
 
-  int stringToState(std::string state)
-  {
-    if (state == "on")
-    {
-      return urc_msgs::msg::StatusLightCommand::ON;
-    }
-    if (state == "off")
-    {
-      return urc_msgs::msg::StatusLightCommand::OFF;
-    }
-    if (state == "blink")
-    {
-      return urc_msgs::msg::StatusLightCommand::BLINK;
-    }
+  throw std::invalid_argument("Invalid color!");
+}
 
-    throw std::invalid_argument("Invalid state!");
+int stringToState(std::string state)
+{
+  if (state == "on") {
+    return urc_msgs::msg::StatusLightCommand::ON;
+  }
+  if (state == "off") {
+    return urc_msgs::msg::StatusLightCommand::OFF;
+  }
+  if (state == "blink") {
+    return urc_msgs::msg::StatusLightCommand::BLINK;
   }
 
-  class StatusLightPublisher : public BT::RosTopicPubNode<urc_msgs::msg::StatusLightCommand>
+  throw std::invalid_argument("Invalid state!");
+}
+
+class StatusLightPublisher : public BT::RosTopicPubNode<urc_msgs::msg::StatusLightCommand>
+{
+public:
+  StatusLightPublisher(
+    const std::string & instance_name, const BT::NodeConfig & conf,
+    const BT::RosNodeParams & params)
+  : BT::RosTopicPubNode<urc_msgs::msg::StatusLightCommand>(instance_name, conf, params) {}
+
+  static BT::PortsList providedPorts()
   {
-  public:
-    StatusLightPublisher(
-        const std::string &instance_name, const BT::NodeConfig &conf,
-        const BT::RosNodeParams &params)
-        : BT::RosTopicPubNode<urc_msgs::msg::StatusLightCommand>(instance_name, conf, params) {}
+    return providedBasicPorts(
+      {BT::InputPort<std::string>("color"),
+        BT::InputPort<std::string>("state")});
+  }
 
-    static BT::PortsList providedPorts()
-    {
-      return providedBasicPorts(
-          {BT::InputPort<std::string>("color"),
-           BT::InputPort<std::string>("state")});
-    }
-
-    bool setMessage(urc_msgs::msg::StatusLightCommand &msg) override;
-  };
+  bool setMessage(urc_msgs::msg::StatusLightCommand & msg) override;
+};
 }
 
 #endif

--- a/urc_bt_nodes/src/actions/status_light_publisher.cpp
+++ b/urc_bt_nodes/src/actions/status_light_publisher.cpp
@@ -4,24 +4,21 @@
 
 namespace behavior::actions
 {
-  bool StatusLightPublisher::setMessage(urc_msgs::msg::StatusLightCommand &msg)
-  {
-    std::string color = getInput<std::string>("color").value();
-    std::string state = getInput<std::string>("state").value();
+bool StatusLightPublisher::setMessage(urc_msgs::msg::StatusLightCommand & msg)
+{
+  std::string color = getInput<std::string>("color").value();
+  std::string state = getInput<std::string>("state").value();
 
-    try
-    {
-      msg.color = stringToColor(color);
-      msg.state = stringToState(state);
-    }
-    catch (std::invalid_argument &e)
-    {
-      RCLCPP_ERROR(node_->get_logger(), "Invalid argument: %s", e.what());
-      return false;
-    }
-
-    return true;
+  try {
+    msg.color = stringToColor(color);
+    msg.state = stringToState(state);
+  } catch (std::invalid_argument & e) {
+    RCLCPP_ERROR(node_->get_logger(), "Invalid argument: %s", e.what());
+    return false;
   }
+
+  return true;
+}
 }
 
 #include "behaviortree_ros2/plugins.hpp"

--- a/urc_bt_nodes/src/actions/status_light_publisher.cpp
+++ b/urc_bt_nodes/src/actions/status_light_publisher.cpp
@@ -4,24 +4,25 @@
 
 namespace behavior::actions
 {
-bool StatusLightPublisher::setMessage(std_msgs::msg::Int8 & msg)
-{
-  msg = getInput<std_msgs::msg::Int8>("value").value();
-  return true;
-}
-}
+  bool StatusLightPublisher::setMessage(urc_msgs::msg::StatusLightCommand &msg)
+  {
+    std::string color = getInput<std::string>("color").value();
+    std::string state = getInput<std::string>("state").value();
 
-namespace BT
-{
-template<>
-inline std_msgs::msg::Int8 convertFromString(StringView str)
-{
-  std_msgs::msg::Int8 output;
-  output.data = convertFromString<int8_t>(str);
-  return output;
-}
-} // namespace BT
+    try
+    {
+      msg.color = stringToColor(color);
+      msg.state = stringToState(state);
+    }
+    catch (std::invalid_argument &e)
+    {
+      RCLCPP_ERROR(node_->get_logger(), "Invalid argument: %s", e.what());
+      return false;
+    }
 
+    return true;
+  }
+}
 
 #include "behaviortree_ros2/plugins.hpp"
 CreateRosNodePlugin(behavior::actions::StatusLightPublisher, "StatusLightPublisher");

--- a/urc_controllers/include/urc_controllers/status_light_controller.hpp
+++ b/urc_controllers/include/urc_controllers/status_light_controller.hpp
@@ -21,59 +21,59 @@
 #include <sensor_msgs/msg/detail/imu__struct.hpp>
 #include "std_msgs/msg/int8.hpp"
 #include <std_msgs/msg/detail/int8__struct.hpp>
+#include <urc_msgs/msg/status_light_command.hpp>
 #include <string>
 #include <vector>
 
 namespace urc_controllers
 {
 
-class StatusLightController : public controller_interface::ControllerInterface
-{
-public:
-  StatusLightController();
+  class StatusLightController : public controller_interface::ControllerInterface
+  {
+  public:
+    StatusLightController();
 
-  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
-  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+    controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+    controller_interface::InterfaceConfiguration state_interface_configuration() const override;
 
-  controller_interface::return_type update(
-    const rclcpp::Time & time,
-    const rclcpp::Duration & period) override;
+    controller_interface::return_type update(
+        const rclcpp::Time &time,
+        const rclcpp::Duration &period) override;
 
-  controller_interface::CallbackReturn on_init() override;
+    controller_interface::CallbackReturn on_init() override;
 
-  controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state)
-  override;
+    controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State &previous_state)
+        override;
 
-  controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state)
-  override;
+    controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State &previous_state)
+        override;
 
-  controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state)
-  override;
+    controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state)
+        override;
 
-  controller_interface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state)
-  override;
+    controller_interface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &previous_state)
+        override;
 
-  controller_interface::CallbackReturn on_error(const rclcpp_lifecycle::State & previous_state)
-  override;
+    controller_interface::CallbackReturn on_error(const rclcpp_lifecycle::State &previous_state)
+        override;
 
-  controller_interface::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & previous_state)
-  override;
+    controller_interface::CallbackReturn on_shutdown(const rclcpp_lifecycle::State &previous_state)
+        override;
 
-protected:
-  // status_light related
-  std::string status_light_name;
-  std::shared_ptr<rclcpp::Subscription<std_msgs::msg::Int8>> color_command_subscriber_;
-  std::shared_ptr<rclcpp::Subscription<std_msgs::msg::Int8>> display_command_subscriber_;
-  realtime_tools::RealtimeBuffer<double> color_command_;
-  realtime_tools::RealtimeBuffer<double> display_command_;
+  protected:
+    // status_light related
+    std::string status_light_name;
+    std::shared_ptr<rclcpp::Subscription<urc_msgs::msg::StatusLightCommand>> status_light_command_subscriber_;
+    realtime_tools::RealtimeBuffer<uint8_t> color_command_;
+    realtime_tools::RealtimeBuffer<uint8_t> state_command_;
 
-  // command interfaces
-  std::unordered_map<std::string,
-    std::shared_ptr<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>>
-  command_interface_map;
-  const std::vector<std::string> STATUS_LIGHT_INTERFACES{"color", "display"};
-};
+    // command interfaces
+    std::unordered_map<std::string,
+                       std::shared_ptr<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>>
+        command_interface_map;
+    const std::vector<std::string> STATUS_LIGHT_INTERFACES{"color", "state"};
+  };
 
-}  // namespace urc_controllers
+} // namespace urc_controllers
 
-#endif  // URC_CONTROLLERS__IMU_BROADCASTER_HPP_
+#endif // URC_CONTROLLERS__IMU_BROADCASTER_HPP_

--- a/urc_controllers/include/urc_controllers/status_light_controller.hpp
+++ b/urc_controllers/include/urc_controllers/status_light_controller.hpp
@@ -28,51 +28,52 @@
 namespace urc_controllers
 {
 
-  class StatusLightController : public controller_interface::ControllerInterface
-  {
-  public:
-    StatusLightController();
+class StatusLightController : public controller_interface::ControllerInterface
+{
+public:
+  StatusLightController();
 
-    controller_interface::InterfaceConfiguration command_interface_configuration() const override;
-    controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
 
-    controller_interface::return_type update(
-        const rclcpp::Time &time,
-        const rclcpp::Duration &period) override;
+  controller_interface::return_type update(
+    const rclcpp::Time & time,
+    const rclcpp::Duration & period) override;
 
-    controller_interface::CallbackReturn on_init() override;
+  controller_interface::CallbackReturn on_init() override;
 
-    controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State &previous_state)
-        override;
+  controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state)
+  override;
 
-    controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State &previous_state)
-        override;
+  controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state)
+  override;
 
-    controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state)
-        override;
+  controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state)
+  override;
 
-    controller_interface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &previous_state)
-        override;
+  controller_interface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state)
+  override;
 
-    controller_interface::CallbackReturn on_error(const rclcpp_lifecycle::State &previous_state)
-        override;
+  controller_interface::CallbackReturn on_error(const rclcpp_lifecycle::State & previous_state)
+  override;
 
-    controller_interface::CallbackReturn on_shutdown(const rclcpp_lifecycle::State &previous_state)
-        override;
+  controller_interface::CallbackReturn on_shutdown(const rclcpp_lifecycle::State & previous_state)
+  override;
 
-  protected:
-    // status_light related
-    std::string status_light_name;
-    std::shared_ptr<rclcpp::Subscription<urc_msgs::msg::StatusLightCommand>> status_light_command_subscriber_;
-    realtime_tools::RealtimeBuffer<uint8_t> color_command_;
-    realtime_tools::RealtimeBuffer<uint8_t> state_command_;
+protected:
+  // status_light related
+  std::string status_light_name;
+  std::shared_ptr<rclcpp::Subscription<urc_msgs::msg::StatusLightCommand>>
+  status_light_command_subscriber_;
+  realtime_tools::RealtimeBuffer<uint8_t> color_command_;
+  realtime_tools::RealtimeBuffer<uint8_t> state_command_;
 
-    // command interfaces
-    std::unordered_map<std::string,
-                       std::shared_ptr<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>>
-        command_interface_map;
-    const std::vector<std::string> STATUS_LIGHT_INTERFACES{"color", "state"};
-  };
+  // command interfaces
+  std::unordered_map<std::string,
+    std::shared_ptr<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>>
+  command_interface_map;
+  const std::vector<std::string> STATUS_LIGHT_INTERFACES{"color", "state"};
+};
 
 } // namespace urc_controllers
 

--- a/urc_controllers/src/status_light_controller.cpp
+++ b/urc_controllers/src/status_light_controller.cpp
@@ -13,125 +13,122 @@
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(
-    urc_controllers::StatusLightController,
-    controller_interface::ControllerInterface);
+  urc_controllers::StatusLightController,
+  controller_interface::ControllerInterface);
 
 namespace urc_controllers
 {
 
-  StatusLightController::StatusLightController()
-      : status_light_command_subscriber_(nullptr), color_command_(0), state_command_(0) {}
+StatusLightController::StatusLightController()
+: status_light_command_subscriber_(nullptr), color_command_(0), state_command_(0) {}
 
-  controller_interface::CallbackReturn StatusLightController::on_init()
-  {
-    return controller_interface::CallbackReturn::SUCCESS;
+controller_interface::CallbackReturn StatusLightController::on_init()
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn StatusLightController::on_configure(
+  const rclcpp_lifecycle::State &)
+{
+  status_light_name = get_node()->get_parameter("status_light_name").as_string();
+  if (status_light_name.empty()) {
+    RCLCPP_ERROR(
+      get_node()->get_logger(),
+      "Need to have 'status_light_name' parameter in the configuration file. Fail to find one.");
+    return controller_interface::CallbackReturn::FAILURE;
   }
+  return controller_interface::CallbackReturn::SUCCESS;
+}
 
-  controller_interface::CallbackReturn StatusLightController::on_configure(
-      const rclcpp_lifecycle::State &)
-  {
-    status_light_name = get_node()->get_parameter("status_light_name").as_string();
-    if (status_light_name.empty())
-    {
-      RCLCPP_ERROR(
-          get_node()->get_logger(),
-          "Need to have 'status_light_name' parameter in the configuration file. Fail to find one.");
-      return controller_interface::CallbackReturn::FAILURE;
-    }
-    return controller_interface::CallbackReturn::SUCCESS;
-  }
+controller_interface::InterfaceConfiguration StatusLightController::command_interface_configuration()
+const
+{
+  controller_interface::InterfaceConfiguration command_interfaces_configuration;
+  command_interfaces_configuration.type =
+    controller_interface::interface_configuration_type::INDIVIDUAL;
 
-  controller_interface::InterfaceConfiguration StatusLightController::command_interface_configuration()
-      const
-  {
-    controller_interface::InterfaceConfiguration command_interfaces_configuration;
-    command_interfaces_configuration.type =
-        controller_interface::interface_configuration_type::INDIVIDUAL;
+  command_interfaces_configuration.names.push_back(status_light_name + "/" + "color");
+  command_interfaces_configuration.names.push_back(status_light_name + "/" + "state");
+  return command_interfaces_configuration;
+}
 
-    command_interfaces_configuration.names.push_back(status_light_name + "/" + "color");
-    command_interfaces_configuration.names.push_back(status_light_name + "/" + "state");
-    return command_interfaces_configuration;
-  }
+controller_interface::InterfaceConfiguration StatusLightController::state_interface_configuration()
+const
+{
+  return controller_interface::InterfaceConfiguration();
+}
 
-  controller_interface::InterfaceConfiguration StatusLightController::state_interface_configuration()
-      const
-  {
-    return controller_interface::InterfaceConfiguration();
-  }
-
-  controller_interface::CallbackReturn StatusLightController::on_activate(
-      const rclcpp_lifecycle::State &)
-  {
-    for (auto &interface : command_interfaces_)
-    {
-      const auto interface_ptr =
-          std::find(
-              STATUS_LIGHT_INTERFACES.begin(),
-              STATUS_LIGHT_INTERFACES.end(), interface.get_interface_name());
-      if (interface_ptr == STATUS_LIGHT_INTERFACES.end())
-      {
-        continue;
-      }
-
-      command_interface_map.emplace(
-          interface.get_interface_name(),
-          std::make_shared<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>(
-              interface));
+controller_interface::CallbackReturn StatusLightController::on_activate(
+  const rclcpp_lifecycle::State &)
+{
+  for (auto & interface : command_interfaces_) {
+    const auto interface_ptr =
+      std::find(
+      STATUS_LIGHT_INTERFACES.begin(),
+      STATUS_LIGHT_INTERFACES.end(), interface.get_interface_name());
+    if (interface_ptr == STATUS_LIGHT_INTERFACES.end()) {
+      continue;
     }
 
-    if (command_interface_map.size() != 2)
+    command_interface_map.emplace(
+      interface.get_interface_name(),
+      std::make_shared<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>(
+        interface));
+  }
+
+  if (command_interface_map.size() != 2) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Not all interfaces are initialized!");
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  status_light_command_subscriber_ =
+    get_node()->create_subscription<urc_msgs::msg::StatusLightCommand>(
+    "/command/status_light", rclcpp::SystemDefaultsQoS(),
+    [this](std::shared_ptr<urc_msgs::msg::StatusLightCommand> msg)
     {
-      RCLCPP_ERROR(get_node()->get_logger(), "Not all interfaces are initialized!");
-      return controller_interface::CallbackReturn::ERROR;
-    }
+      color_command_.writeFromNonRT(static_cast<uint8_t>(msg->color));
+      state_command_.writeFromNonRT(static_cast<uint8_t>(msg->state));
+    });
 
-    status_light_command_subscriber_ = get_node()->create_subscription<urc_msgs::msg::StatusLightCommand>(
-        "/command/status_light", rclcpp::SystemDefaultsQoS(),
-        [this](std::shared_ptr<urc_msgs::msg::StatusLightCommand> msg)
-        {
-          color_command_.writeFromNonRT(static_cast<uint8_t>(msg->color));
-          state_command_.writeFromNonRT(static_cast<uint8_t>(msg->state));
-        });
+  RCLCPP_INFO(get_node()->get_logger(), "StatusLightController activated!");
+  return controller_interface::CallbackReturn::SUCCESS;
+}
 
-    RCLCPP_INFO(get_node()->get_logger(), "StatusLightController activated!");
-    return controller_interface::CallbackReturn::SUCCESS;
-  }
+controller_interface::CallbackReturn StatusLightController::on_deactivate(
+  const rclcpp_lifecycle::State &)
+{
+  status_light_command_subscriber_.reset();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
 
-  controller_interface::CallbackReturn StatusLightController::on_deactivate(
-      const rclcpp_lifecycle::State &)
-  {
-    status_light_command_subscriber_.reset();
-    return controller_interface::CallbackReturn::SUCCESS;
-  }
+controller_interface::CallbackReturn StatusLightController::on_cleanup(
+  const rclcpp_lifecycle::State &)
+{
+  status_light_command_subscriber_.reset();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
 
-  controller_interface::CallbackReturn StatusLightController::on_cleanup(
-      const rclcpp_lifecycle::State &)
-  {
-    status_light_command_subscriber_.reset();
-    return controller_interface::CallbackReturn::SUCCESS;
-  }
+controller_interface::CallbackReturn StatusLightController::on_error(
+  const rclcpp_lifecycle::State &)
+{
+  status_light_command_subscriber_.reset();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
 
-  controller_interface::CallbackReturn StatusLightController::on_error(
-      const rclcpp_lifecycle::State &)
-  {
-    status_light_command_subscriber_.reset();
-    return controller_interface::CallbackReturn::SUCCESS;
-  }
+controller_interface::CallbackReturn StatusLightController::on_shutdown(
+  const rclcpp_lifecycle::State &)
+{
+  status_light_command_subscriber_.reset();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
 
-  controller_interface::CallbackReturn StatusLightController::on_shutdown(
-      const rclcpp_lifecycle::State &)
-  {
-    status_light_command_subscriber_.reset();
-    return controller_interface::CallbackReturn::SUCCESS;
-  }
-
-  controller_interface::return_type StatusLightController::update(
-      const rclcpp::Time &,
-      const rclcpp::Duration &)
-  {
-    command_interface_map["color"]->get().set_value(*color_command_.readFromRT());
-    command_interface_map["state"]->get().set_value(*state_command_.readFromRT());
-    return controller_interface::return_type::OK;
-  }
+controller_interface::return_type StatusLightController::update(
+  const rclcpp::Time &,
+  const rclcpp::Duration &)
+{
+  command_interface_map["color"]->get().set_value(*color_command_.readFromRT());
+  command_interface_map["state"]->get().set_value(*state_command_.readFromRT());
+  return controller_interface::return_type::OK;
+}
 
 } // namespace urc_controllers

--- a/urc_controllers/src/status_light_controller.cpp
+++ b/urc_controllers/src/status_light_controller.cpp
@@ -13,131 +13,125 @@
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(
-  urc_controllers::StatusLightController,
-  controller_interface::ControllerInterface);
+    urc_controllers::StatusLightController,
+    controller_interface::ControllerInterface);
 
 namespace urc_controllers
 {
 
-StatusLightController::StatusLightController()
-: color_command_subscriber_(nullptr)
-  , display_command_subscriber_(nullptr)
-  , color_command_(0.0)
-  , display_command_(0.0) {}
+  StatusLightController::StatusLightController()
+      : status_light_command_subscriber_(nullptr), color_command_(0), state_command_(0) {}
 
-controller_interface::CallbackReturn StatusLightController::on_init()
-{
-  return controller_interface::CallbackReturn::SUCCESS;
-}
-
-controller_interface::CallbackReturn StatusLightController::on_configure(
-  const rclcpp_lifecycle::State &)
-{
-  status_light_name = get_node()->get_parameter("status_light_name").as_string();
-  if (status_light_name.empty()) {
-    RCLCPP_ERROR(
-      get_node()->get_logger(),
-      "Need to have 'status_light_name' parameter in the configuration file. Fail to find one.");
-    return controller_interface::CallbackReturn::FAILURE;
+  controller_interface::CallbackReturn StatusLightController::on_init()
+  {
+    return controller_interface::CallbackReturn::SUCCESS;
   }
-  return controller_interface::CallbackReturn::SUCCESS;
-}
 
-controller_interface::InterfaceConfiguration StatusLightController::command_interface_configuration()
-const
-{
-  controller_interface::InterfaceConfiguration command_interfaces_configuration;
-  command_interfaces_configuration.type =
-    controller_interface::interface_configuration_type::INDIVIDUAL;
+  controller_interface::CallbackReturn StatusLightController::on_configure(
+      const rclcpp_lifecycle::State &)
+  {
+    status_light_name = get_node()->get_parameter("status_light_name").as_string();
+    if (status_light_name.empty())
+    {
+      RCLCPP_ERROR(
+          get_node()->get_logger(),
+          "Need to have 'status_light_name' parameter in the configuration file. Fail to find one.");
+      return controller_interface::CallbackReturn::FAILURE;
+    }
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
 
-  command_interfaces_configuration.names.push_back(status_light_name + "/" + "color");
-  command_interfaces_configuration.names.push_back(status_light_name + "/" + "display");
-  return command_interfaces_configuration;
-}
+  controller_interface::InterfaceConfiguration StatusLightController::command_interface_configuration()
+      const
+  {
+    controller_interface::InterfaceConfiguration command_interfaces_configuration;
+    command_interfaces_configuration.type =
+        controller_interface::interface_configuration_type::INDIVIDUAL;
 
-controller_interface::InterfaceConfiguration StatusLightController::state_interface_configuration()
-const
-{
-  return controller_interface::InterfaceConfiguration();
-}
+    command_interfaces_configuration.names.push_back(status_light_name + "/" + "color");
+    command_interfaces_configuration.names.push_back(status_light_name + "/" + "state");
+    return command_interfaces_configuration;
+  }
 
-controller_interface::CallbackReturn StatusLightController::on_activate(
-  const rclcpp_lifecycle::State &)
-{
-  for (auto & interface : command_interfaces_) {
-    const auto interface_ptr =
-      std::find(
-      STATUS_LIGHT_INTERFACES.begin(),
-      STATUS_LIGHT_INTERFACES.end(), interface.get_interface_name());
-    if (interface_ptr == STATUS_LIGHT_INTERFACES.end()) {
-      continue;
+  controller_interface::InterfaceConfiguration StatusLightController::state_interface_configuration()
+      const
+  {
+    return controller_interface::InterfaceConfiguration();
+  }
+
+  controller_interface::CallbackReturn StatusLightController::on_activate(
+      const rclcpp_lifecycle::State &)
+  {
+    for (auto &interface : command_interfaces_)
+    {
+      const auto interface_ptr =
+          std::find(
+              STATUS_LIGHT_INTERFACES.begin(),
+              STATUS_LIGHT_INTERFACES.end(), interface.get_interface_name());
+      if (interface_ptr == STATUS_LIGHT_INTERFACES.end())
+      {
+        continue;
+      }
+
+      command_interface_map.emplace(
+          interface.get_interface_name(),
+          std::make_shared<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>(
+              interface));
     }
 
-    command_interface_map.emplace(
-      interface.get_interface_name(),
-      std::make_shared<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>(
-        interface));
+    if (command_interface_map.size() != 2)
+    {
+      RCLCPP_ERROR(get_node()->get_logger(), "Not all interfaces are initialized!");
+      return controller_interface::CallbackReturn::ERROR;
+    }
+
+    status_light_command_subscriber_ = get_node()->create_subscription<urc_msgs::msg::StatusLightCommand>(
+        "/command/status_light", rclcpp::SystemDefaultsQoS(),
+        [this](std::shared_ptr<urc_msgs::msg::StatusLightCommand> msg)
+        {
+          color_command_.writeFromNonRT(static_cast<uint8_t>(msg->color));
+          state_command_.writeFromNonRT(static_cast<uint8_t>(msg->state));
+        });
+
+    RCLCPP_INFO(get_node()->get_logger(), "StatusLightController activated!");
+    return controller_interface::CallbackReturn::SUCCESS;
   }
 
-  if (command_interface_map.size() != 2) {
-    RCLCPP_ERROR(get_node()->get_logger(), "Not all interfaces are initialized!");
-    return controller_interface::CallbackReturn::ERROR;
+  controller_interface::CallbackReturn StatusLightController::on_deactivate(
+      const rclcpp_lifecycle::State &)
+  {
+    status_light_command_subscriber_.reset();
+    return controller_interface::CallbackReturn::SUCCESS;
   }
 
-  color_command_subscriber_ = get_node()->create_subscription<std_msgs::msg::Int8>(
-    "/cmd_statuslight_color", rclcpp::SystemDefaultsQoS(),
-    [this](std::shared_ptr<std_msgs::msg::Int8> message) {
-      color_command_.writeFromNonRT(static_cast<double>(message->data));
-    });
-  display_command_subscriber_ = get_node()->create_subscription<std_msgs::msg::Int8>(
-    "/cmd_statuslight_display", rclcpp::SystemDefaultsQoS(),
-    [this](std::shared_ptr<std_msgs::msg::Int8> message) {
-      display_command_.writeFromNonRT(static_cast<double>(message->data));
-    });
+  controller_interface::CallbackReturn StatusLightController::on_cleanup(
+      const rclcpp_lifecycle::State &)
+  {
+    status_light_command_subscriber_.reset();
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
 
-  RCLCPP_INFO(get_node()->get_logger(), "StatusLightController activated!");
-  return controller_interface::CallbackReturn::SUCCESS;
-}
+  controller_interface::CallbackReturn StatusLightController::on_error(
+      const rclcpp_lifecycle::State &)
+  {
+    status_light_command_subscriber_.reset();
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
 
-controller_interface::CallbackReturn StatusLightController::on_deactivate(
-  const rclcpp_lifecycle::State &)
-{
-  color_command_subscriber_.reset();
-  display_command_subscriber_.reset();
-  return controller_interface::CallbackReturn::SUCCESS;
-}
+  controller_interface::CallbackReturn StatusLightController::on_shutdown(
+      const rclcpp_lifecycle::State &)
+  {
+    status_light_command_subscriber_.reset();
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
 
-controller_interface::CallbackReturn StatusLightController::on_cleanup(
-  const rclcpp_lifecycle::State &)
-{
-  color_command_subscriber_.reset();
-  display_command_subscriber_.reset();
-  return controller_interface::CallbackReturn::SUCCESS;
-}
+  controller_interface::return_type StatusLightController::update(
+      const rclcpp::Time &,
+      const rclcpp::Duration &)
+  {
+    command_interface_map["color"]->get().set_value(*color_command_.readFromRT());
+    command_interface_map["state"]->get().set_value(*state_command_.readFromRT());
+    return controller_interface::return_type::OK;
+  }
 
-controller_interface::CallbackReturn StatusLightController::on_error(
-  const rclcpp_lifecycle::State &)
-{
-  color_command_subscriber_.reset();
-  display_command_subscriber_.reset();
-  return controller_interface::CallbackReturn::SUCCESS;
-}
-
-controller_interface::CallbackReturn StatusLightController::on_shutdown(
-  const rclcpp_lifecycle::State &)
-{
-  color_command_subscriber_.reset();
-  display_command_subscriber_.reset();
-  return controller_interface::CallbackReturn::SUCCESS;
-}
-
-controller_interface::return_type StatusLightController::update(
-  const rclcpp::Time &,
-  const rclcpp::Duration &)
-{
-  command_interface_map["color"]->get().set_value(*color_command_.readFromRT());
-  command_interface_map["display"]->get().set_value(*display_command_.readFromRT());
-  return controller_interface::return_type::OK;
-}
-
-}  // namespace urc_controllers
+} // namespace urc_controllers

--- a/urc_hw/include/urc_hw/hardware_interfaces/status_light.hpp
+++ b/urc_hw/include/urc_hw/hardware_interfaces/status_light.hpp
@@ -18,50 +18,62 @@
 
 namespace urc_hardware::hardware_interfaces
 {
+  std::string num_to_state(uint8_t num)
+  {
+    switch (num)
+    {
+    case 0:
+      return "off";
+    case 1:
+      return "on";
+    case 2:
+      return "blinking";
+    default:
+      return "unknown";
+    }
+  }
 
-class StatusLight : public hardware_interface::SystemInterface
-{
-public:
-  StatusLight();
-  ~StatusLight();
+  class StatusLight : public hardware_interface::SystemInterface
+  {
+  public:
+    StatusLight();
+    ~StatusLight();
 
-  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & hardware_info)
-  override;
-  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
-  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
-  hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state)
-  override;
-  hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state)
-  override;
-  hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state)
-  override;
-  hardware_interface::return_type read(
-    const rclcpp::Time & time,
-    const rclcpp::Duration & period) override;
-  hardware_interface::return_type write(
-    const rclcpp::Time & time,
-    const rclcpp::Duration & period) override;
+    hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo &hardware_info)
+        override;
+    std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+    std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+    hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State &previous_state)
+        override;
+    hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State &previous_state)
+        override;
+    hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state)
+        override;
+    hardware_interface::return_type read(
+        const rclcpp::Time &time,
+        const rclcpp::Duration &period) override;
+    hardware_interface::return_type write(
+        const rclcpp::Time &time,
+        const rclcpp::Duration &period) override;
 
-private:
-  // basic info
-  const std::string hardware_interface_name;
-  // states
-  std::vector<double> signals;  // [0]: color choice, [1]: display mode(e.g. flashing / idle / double flashing)
+  private:
+    // basic info
+    const std::string hardware_interface_name;
+    // states
+    std::vector<double> signals; // [0]: color selection, [1]: state (on, off, blinking)
 
-  // hardware resources
-  std::shared_ptr<UDPSocket<128>> udp_;
-  std::string udp_address;
-  std::string udp_port;
+    // hardware resources
+    std::shared_ptr<UDPSocket<128>> udp_;
+    std::string udp_address;
+    std::string udp_port;
 
-  // nanopb
-  uint8_t buffer[TeensyMessage_size];
-  size_t message_length;
+    // nanopb
+    uint8_t buffer[TeensyMessage_size];
+    size_t message_length;
 
-  // private info for lights
-  uint8_t currentLight = 0;
-  uint8_t lightModes[3]; // current pattern for each of 3 lights
-};
+    uint8_t lightStates[3]; // current state of each light (red, green, blue).
+  };
 
-}  // namespace urc_hardware::hardware_interfaces
+} // namespace urc_hardware::hardware_interfaces
 
-#endif  // URC_HW__STATUS_LIGHT_HW_INTERFACE_HPP
+#endif // URC_HW__STATUS_LIGHT_HW_INTERFACE_HPP

--- a/urc_hw/include/urc_hw/hardware_interfaces/status_light.hpp
+++ b/urc_hw/include/urc_hw/hardware_interfaces/status_light.hpp
@@ -18,10 +18,9 @@
 
 namespace urc_hardware::hardware_interfaces
 {
-  std::string num_to_state(uint8_t num)
-  {
-    switch (num)
-    {
+std::string num_to_state(uint8_t num)
+{
+  switch (num) {
     case 0:
       return "off";
     case 1:
@@ -30,49 +29,49 @@ namespace urc_hardware::hardware_interfaces
       return "blinking";
     default:
       return "unknown";
-    }
   }
+}
 
-  class StatusLight : public hardware_interface::SystemInterface
-  {
-  public:
-    StatusLight();
-    ~StatusLight();
+class StatusLight : public hardware_interface::SystemInterface
+{
+public:
+  StatusLight();
+  ~StatusLight();
 
-    hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo &hardware_info)
-        override;
-    std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
-    std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
-    hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State &previous_state)
-        override;
-    hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State &previous_state)
-        override;
-    hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state)
-        override;
-    hardware_interface::return_type read(
-        const rclcpp::Time &time,
-        const rclcpp::Duration &period) override;
-    hardware_interface::return_type write(
-        const rclcpp::Time &time,
-        const rclcpp::Duration &period) override;
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & hardware_info)
+  override;
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+  hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state)
+  override;
+  hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state)
+  override;
+  hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state)
+  override;
+  hardware_interface::return_type read(
+    const rclcpp::Time & time,
+    const rclcpp::Duration & period) override;
+  hardware_interface::return_type write(
+    const rclcpp::Time & time,
+    const rclcpp::Duration & period) override;
 
-  private:
-    // basic info
-    const std::string hardware_interface_name;
-    // states
-    std::vector<double> signals; // [0]: color selection, [1]: state (on, off, blinking)
+private:
+  // basic info
+  const std::string hardware_interface_name;
+  // states
+  std::vector<double> signals;   // [0]: color selection, [1]: state (on, off, blinking)
 
-    // hardware resources
-    std::shared_ptr<UDPSocket<128>> udp_;
-    std::string udp_address;
-    std::string udp_port;
+  // hardware resources
+  std::shared_ptr<UDPSocket<128>> udp_;
+  std::string udp_address;
+  std::string udp_port;
 
-    // nanopb
-    uint8_t buffer[TeensyMessage_size];
-    size_t message_length;
+  // nanopb
+  uint8_t buffer[TeensyMessage_size];
+  size_t message_length;
 
-    uint8_t lightStates[3]; // current state of each light (red, green, blue).
-  };
+  uint8_t lightStates[3];   // current state of each light (red, green, blue).
+};
 
 } // namespace urc_hardware::hardware_interfaces
 

--- a/urc_hw/src/hardware_interfaces/status_light.cpp
+++ b/urc_hw/src/hardware_interfaces/status_light.cpp
@@ -14,159 +14,157 @@
 #include <urc_nanopb/urc.pb.h>
 
 PLUGINLIB_EXPORT_CLASS(
-    urc_hardware::hardware_interfaces::StatusLight,
-    hardware_interface::SystemInterface);
+  urc_hardware::hardware_interfaces::StatusLight,
+  hardware_interface::SystemInterface);
 
 namespace urc_hardware::hardware_interfaces
 {
 
-  StatusLight::StatusLight()
-      : hardware_interface_name("Status Light"), signals(2, 0) {}
-  StatusLight::~StatusLight() = default;
+StatusLight::StatusLight()
+: hardware_interface_name("Status Light"), signals(2, 0) {}
+StatusLight::~StatusLight() = default;
 
-  hardware_interface::CallbackReturn StatusLight::on_init(
-      const hardware_interface::HardwareInfo &info)
+hardware_interface::CallbackReturn StatusLight::on_init(
+  const hardware_interface::HardwareInfo & info)
+{
+  if (hardware_interface::SystemInterface::on_init(info) !=
+    hardware_interface::CallbackReturn::SUCCESS)
   {
-    if (hardware_interface::SystemInterface::on_init(info) !=
-        hardware_interface::CallbackReturn::SUCCESS)
-    {
-      return hardware_interface::CallbackReturn::ERROR;
-    }
-
-    if (info_.hardware_parameters.find("udp_address") == info_.hardware_parameters.end())
-    {
-      RCLCPP_ERROR(
-          rclcpp::get_logger(hardware_interface_name),
-          "Error during initialization: 'udp_address' configuration not "
-          "found. Expect to enter the udp server address.");
-      return hardware_interface::CallbackReturn::ERROR;
-    }
-    if (info_.hardware_parameters.find("udp_port") == info_.hardware_parameters.end())
-    {
-      RCLCPP_ERROR(
-          rclcpp::get_logger(hardware_interface_name),
-          "Error during initialization: 'udp_port' configuration not "
-          "found. Expect to enter the port number.");
-      return hardware_interface::CallbackReturn::ERROR;
-    }
-
-    udp_address = info_.hardware_parameters["udp_address"];
-    udp_port = info_.hardware_parameters["udp_port"];
-
-    if (info.gpios.size() == 0)
-    {
-      RCLCPP_ERROR(
-          rclcpp::get_logger(
-              hardware_interface_name),
-          "Should have at least one gpio to be the Status Light.");
-      return CallbackReturn::ERROR;
-    }
-
-    bool find_light = false;
-    for (hardware_interface::ComponentInfo component : info_.gpios)
-    {
-      if (component.name == "status_light")
-      {
-        find_light = true;
-        break;
-      }
-    }
-
-    if (!find_light)
-    {
-      RCLCPP_ERROR(
-          rclcpp::get_logger(
-              hardware_interface_name),
-          "Not able to find sensor named 'status_light'.");
-      return CallbackReturn::ERROR;
-    }
-
-    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light HW interface initialized!");
-    return hardware_interface::CallbackReturn::SUCCESS;
+    return hardware_interface::CallbackReturn::ERROR;
   }
 
-  hardware_interface::CallbackReturn StatusLight::on_configure(const rclcpp_lifecycle::State &)
-  {
-    std::fill(signals.begin(), signals.end(), 0.0);
-    return hardware_interface::CallbackReturn::SUCCESS;
+  if (info_.hardware_parameters.find("udp_address") == info_.hardware_parameters.end()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(hardware_interface_name),
+      "Error during initialization: 'udp_address' configuration not "
+      "found. Expect to enter the udp server address.");
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+  if (info_.hardware_parameters.find("udp_port") == info_.hardware_parameters.end()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(hardware_interface_name),
+      "Error during initialization: 'udp_port' configuration not "
+      "found. Expect to enter the port number.");
+    return hardware_interface::CallbackReturn::ERROR;
   }
 
-  std::vector<hardware_interface::CommandInterface> StatusLight::export_command_interfaces()
-  {
-    std::vector<hardware_interface::CommandInterface> command_interfaces;
-    command_interfaces.emplace_back("status_light", "color", &this->signals[0]);
-    command_interfaces.emplace_back("status_light", "state", &this->signals[1]);
-    return command_interfaces;
+  udp_address = info_.hardware_parameters["udp_address"];
+  udp_port = info_.hardware_parameters["udp_port"];
+
+  if (info.gpios.size() == 0) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(
+        hardware_interface_name),
+      "Should have at least one gpio to be the Status Light.");
+    return CallbackReturn::ERROR;
   }
 
-  std::vector<hardware_interface::StateInterface> StatusLight::export_state_interfaces()
-  {
-    std::vector<hardware_interface::StateInterface> state_interfaces;
-    return state_interfaces;
-  }
-
-  hardware_interface::CallbackReturn StatusLight::on_activate(const rclcpp_lifecycle::State &)
-  {
-    udp_ = std::make_shared<UDPSocket<128>>(true);
-    udp_->Connect(udp_address, std::stoi(udp_port));
-    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light activated!");
-    return hardware_interface::CallbackReturn::SUCCESS;
-  }
-
-  hardware_interface::CallbackReturn StatusLight::on_deactivate(const rclcpp_lifecycle::State &)
-  {
-    udp_->Close();
-    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light deactivated!");
-    return hardware_interface::CallbackReturn::SUCCESS;
-  }
-
-  hardware_interface::return_type StatusLight::read(const rclcpp::Time &, const rclcpp::Duration &)
-  {
-    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Red: %s, Green: %s, Blue: %s", num_to_state(lightStates[0]).c_str(), num_to_state(lightStates[1]).c_str(), num_to_state(lightStates[2]).c_str());
-
-    return hardware_interface::return_type::OK;
-  }
-
-  hardware_interface::return_type StatusLight::write(const rclcpp::Time &, const rclcpp::Duration &)
-  {
-
-    TeensyMessage message = TeensyMessage_init_zero;
-    pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
-
-    uint8_t selected_color = static_cast<uint8_t>(signals[0]);
-    uint8_t selected_state = static_cast<uint8_t>(signals[1]);
-    if (selected_color >= 0 && selected_color <= 2 && selected_state >= 0 && selected_state <= 2)
-    {
-      lightStates[selected_color] = selected_state;
+  bool find_light = false;
+  for (hardware_interface::ComponentInfo component : info_.gpios) {
+    if (component.name == "status_light") {
+      find_light = true;
+      break;
     }
-
-    message.redEnabled = (lightStates[0] != 0);
-    message.redBlink = (lightStates[0] == 2);
-    message.greenEnabled = (lightStates[1] != 0);
-    message.greenBlink = (lightStates[1] == 2);
-    message.blueEnabled = (lightStates[2] != 0);
-    message.blueBlink = (lightStates[2] == 2);
-
-    // Fill Required Fields
-    message.m1Setpoint = 0;
-    message.m2Setpoint = 0;
-    message.m3Setpoint = 0;
-    message.m4Setpoint = 0;
-    message.m5Setpoint = 0;
-    message.m6Setpoint = 0;
-
-    // Set message id to status light
-    message.messageID = 1;
-
-    bool status = pb_encode(&stream, TeensyMessage_fields, &message);
-    message_length = stream.bytes_written;
-
-    if (!status)
-    {
-      return hardware_interface::return_type::ERROR;
-    }
-    udp_->Send((char *)buffer, sizeof(buffer));
-    return hardware_interface::return_type::OK;
   }
+
+  if (!find_light) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(
+        hardware_interface_name),
+      "Not able to find sensor named 'status_light'.");
+    return CallbackReturn::ERROR;
+  }
+
+  RCLCPP_INFO(
+    rclcpp::get_logger(hardware_interface_name),
+    "Status light HW interface initialized!");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn StatusLight::on_configure(const rclcpp_lifecycle::State &)
+{
+  std::fill(signals.begin(), signals.end(), 0.0);
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::CommandInterface> StatusLight::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+  command_interfaces.emplace_back("status_light", "color", &this->signals[0]);
+  command_interfaces.emplace_back("status_light", "state", &this->signals[1]);
+  return command_interfaces;
+}
+
+std::vector<hardware_interface::StateInterface> StatusLight::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  return state_interfaces;
+}
+
+hardware_interface::CallbackReturn StatusLight::on_activate(const rclcpp_lifecycle::State &)
+{
+  udp_ = std::make_shared<UDPSocket<128>>(true);
+  udp_->Connect(udp_address, std::stoi(udp_port));
+  RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light activated!");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn StatusLight::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  udp_->Close();
+  RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light deactivated!");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type StatusLight::read(const rclcpp::Time &, const rclcpp::Duration &)
+{
+  RCLCPP_INFO(
+    rclcpp::get_logger(
+      hardware_interface_name), "Red: %s, Green: %s, Blue: %s", num_to_state(
+      lightStates[0]).c_str(), num_to_state(lightStates[1]).c_str(), num_to_state(
+      lightStates[2]).c_str());
+
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type StatusLight::write(const rclcpp::Time &, const rclcpp::Duration &)
+{
+
+  TeensyMessage message = TeensyMessage_init_zero;
+  pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+
+  uint8_t selected_color = static_cast<uint8_t>(signals[0]);
+  uint8_t selected_state = static_cast<uint8_t>(signals[1]);
+  if (selected_color >= 0 && selected_color <= 2 && selected_state >= 0 && selected_state <= 2) {
+    lightStates[selected_color] = selected_state;
+  }
+
+  message.redEnabled = (lightStates[0] != 0);
+  message.redBlink = (lightStates[0] == 2);
+  message.greenEnabled = (lightStates[1] != 0);
+  message.greenBlink = (lightStates[1] == 2);
+  message.blueEnabled = (lightStates[2] != 0);
+  message.blueBlink = (lightStates[2] == 2);
+
+  // Fill Required Fields
+  message.m1Setpoint = 0;
+  message.m2Setpoint = 0;
+  message.m3Setpoint = 0;
+  message.m4Setpoint = 0;
+  message.m5Setpoint = 0;
+  message.m6Setpoint = 0;
+
+  // Set message id to status light
+  message.messageID = 1;
+
+  bool status = pb_encode(&stream, TeensyMessage_fields, &message);
+  message_length = stream.bytes_written;
+
+  if (!status) {
+    return hardware_interface::return_type::ERROR;
+  }
+  udp_->Send((char *)buffer, sizeof(buffer));
+  return hardware_interface::return_type::OK;
+}
 
 } // namespace urc_hardware::hardware_interfaces

--- a/urc_hw/src/hardware_interfaces/status_light.cpp
+++ b/urc_hw/src/hardware_interfaces/status_light.cpp
@@ -14,143 +14,159 @@
 #include <urc_nanopb/urc.pb.h>
 
 PLUGINLIB_EXPORT_CLASS(
-  urc_hardware::hardware_interfaces::StatusLight,
-  hardware_interface::SystemInterface);
+    urc_hardware::hardware_interfaces::StatusLight,
+    hardware_interface::SystemInterface);
 
 namespace urc_hardware::hardware_interfaces
 {
 
-StatusLight::StatusLight()
-: hardware_interface_name("Status Light"), signals(2, 0) {}
-StatusLight::~StatusLight() = default;
+  StatusLight::StatusLight()
+      : hardware_interface_name("Status Light"), signals(2, 0) {}
+  StatusLight::~StatusLight() = default;
 
-hardware_interface::CallbackReturn StatusLight::on_init(
-  const hardware_interface::HardwareInfo & info)
-{
-  if (hardware_interface::SystemInterface::on_init(info) !=
-    hardware_interface::CallbackReturn::SUCCESS)
+  hardware_interface::CallbackReturn StatusLight::on_init(
+      const hardware_interface::HardwareInfo &info)
   {
-    return hardware_interface::CallbackReturn::ERROR;
-  }
-
-  if (info_.hardware_parameters.find("udp_address") == info_.hardware_parameters.end()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(hardware_interface_name),
-      "Error during initialization: 'udp_address' configuration not "
-      "found. Expect to enter the udp server address.");
-    return hardware_interface::CallbackReturn::ERROR;
-  }
-  if (info_.hardware_parameters.find("udp_port") == info_.hardware_parameters.end()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(hardware_interface_name),
-      "Error during initialization: 'udp_port' configuration not "
-      "found. Expect to enter the port number.");
-    return hardware_interface::CallbackReturn::ERROR;
-  }
-
-  udp_address = info_.hardware_parameters["udp_address"];
-  udp_port = info_.hardware_parameters["udp_port"];
-
-  if (info.gpios.size() == 0) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(
-        hardware_interface_name), "Should have at least one gpio to be the Status Light.");
-    return CallbackReturn::ERROR;
-  }
-
-  bool find_light = false;
-  for (hardware_interface::ComponentInfo component : info_.gpios) {
-    if (component.name == "status_light") {
-      find_light = true;
-      break;
+    if (hardware_interface::SystemInterface::on_init(info) !=
+        hardware_interface::CallbackReturn::SUCCESS)
+    {
+      return hardware_interface::CallbackReturn::ERROR;
     }
+
+    if (info_.hardware_parameters.find("udp_address") == info_.hardware_parameters.end())
+    {
+      RCLCPP_ERROR(
+          rclcpp::get_logger(hardware_interface_name),
+          "Error during initialization: 'udp_address' configuration not "
+          "found. Expect to enter the udp server address.");
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+    if (info_.hardware_parameters.find("udp_port") == info_.hardware_parameters.end())
+    {
+      RCLCPP_ERROR(
+          rclcpp::get_logger(hardware_interface_name),
+          "Error during initialization: 'udp_port' configuration not "
+          "found. Expect to enter the port number.");
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    udp_address = info_.hardware_parameters["udp_address"];
+    udp_port = info_.hardware_parameters["udp_port"];
+
+    if (info.gpios.size() == 0)
+    {
+      RCLCPP_ERROR(
+          rclcpp::get_logger(
+              hardware_interface_name),
+          "Should have at least one gpio to be the Status Light.");
+      return CallbackReturn::ERROR;
+    }
+
+    bool find_light = false;
+    for (hardware_interface::ComponentInfo component : info_.gpios)
+    {
+      if (component.name == "status_light")
+      {
+        find_light = true;
+        break;
+      }
+    }
+
+    if (!find_light)
+    {
+      RCLCPP_ERROR(
+          rclcpp::get_logger(
+              hardware_interface_name),
+          "Not able to find sensor named 'status_light'.");
+      return CallbackReturn::ERROR;
+    }
+
+    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light HW interface initialized!");
+    return hardware_interface::CallbackReturn::SUCCESS;
   }
 
-  if (!find_light) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(
-        hardware_interface_name), "Not able to find sensor named 'status_light'.");
-    return CallbackReturn::ERROR;
-  }
-  return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-hardware_interface::CallbackReturn StatusLight::on_configure(const rclcpp_lifecycle::State &)
-{
-  std::fill(signals.begin(), signals.end(), 0.0);
-  return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-std::vector<hardware_interface::CommandInterface> StatusLight::export_command_interfaces()
-{
-  std::vector<hardware_interface::CommandInterface> command_interfaces;
-  command_interfaces.emplace_back("status_light", "color", &this->signals[0]);
-  command_interfaces.emplace_back("status_light", "display", &this->signals[1]);
-  return command_interfaces;
-}
-
-std::vector<hardware_interface::StateInterface> StatusLight::export_state_interfaces()
-{
-  std::vector<hardware_interface::StateInterface> state_interfaces;
-  return state_interfaces;
-}
-
-hardware_interface::CallbackReturn StatusLight::on_activate(const rclcpp_lifecycle::State &)
-{
-  udp_ = std::make_shared<UDPSocket<128>>(true);
-  udp_->Connect(udp_address, std::stoi(udp_port));
-  RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "StatusLight activated!");
-  return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-hardware_interface::CallbackReturn StatusLight::on_deactivate(const rclcpp_lifecycle::State &)
-{
-  udp_->Close();
-  RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "StatusLight deactivated!");
-  return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-hardware_interface::return_type StatusLight::read(const rclcpp::Time &, const rclcpp::Duration &)
-{
-  return hardware_interface::return_type::OK;
-}
-
-hardware_interface::return_type StatusLight::write(const rclcpp::Time &, const rclcpp::Duration &)
-{
-
-  TeensyMessage message = TeensyMessage_init_zero;
-  pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
-
-  currentLight = signals[0];
-  if (currentLight >= 0 && currentLight < 3 && signals[1] >= 0 && signals[1] < 3) {
-    lightModes[currentLight] = signals[1];
+  hardware_interface::CallbackReturn StatusLight::on_configure(const rclcpp_lifecycle::State &)
+  {
+    std::fill(signals.begin(), signals.end(), 0.0);
+    return hardware_interface::CallbackReturn::SUCCESS;
   }
 
-  message.redEnabled = (lightModes[0] != 0);
-  message.redBlink = (lightModes[0] == 2);
-  message.blueEnabled = (lightModes[1] != 0);
-  message.blueBlink = (lightModes[1] == 2);
-  message.greenEnabled = (lightModes[2] != 0);
-  message.greenBlink = (lightModes[2] == 2);
-
-  // Fill Required Fields
-  message.m1Setpoint = 0;
-  message.m2Setpoint = 0;
-  message.m3Setpoint = 0;
-  message.m4Setpoint = 0;
-  message.m5Setpoint = 0;
-  message.m6Setpoint = 0;
-
-  message.messageID = 1;
-
-  bool status = pb_encode(&stream, TeensyMessage_fields, &message);
-  message_length = stream.bytes_written;
-
-  if (!status) {
-    return hardware_interface::return_type::ERROR;
+  std::vector<hardware_interface::CommandInterface> StatusLight::export_command_interfaces()
+  {
+    std::vector<hardware_interface::CommandInterface> command_interfaces;
+    command_interfaces.emplace_back("status_light", "color", &this->signals[0]);
+    command_interfaces.emplace_back("status_light", "state", &this->signals[1]);
+    return command_interfaces;
   }
-  udp_->Send((char *)buffer, sizeof(buffer));
-  return hardware_interface::return_type::OK;
-}
 
-}  // namespace urc_hardware::hardware_interfaces
+  std::vector<hardware_interface::StateInterface> StatusLight::export_state_interfaces()
+  {
+    std::vector<hardware_interface::StateInterface> state_interfaces;
+    return state_interfaces;
+  }
+
+  hardware_interface::CallbackReturn StatusLight::on_activate(const rclcpp_lifecycle::State &)
+  {
+    udp_ = std::make_shared<UDPSocket<128>>(true);
+    udp_->Connect(udp_address, std::stoi(udp_port));
+    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light activated!");
+    return hardware_interface::CallbackReturn::SUCCESS;
+  }
+
+  hardware_interface::CallbackReturn StatusLight::on_deactivate(const rclcpp_lifecycle::State &)
+  {
+    udp_->Close();
+    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Status light deactivated!");
+    return hardware_interface::CallbackReturn::SUCCESS;
+  }
+
+  hardware_interface::return_type StatusLight::read(const rclcpp::Time &, const rclcpp::Duration &)
+  {
+    RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Red: %s, Green: %s, Blue: %s", num_to_state(lightStates[0]).c_str(), num_to_state(lightStates[1]).c_str(), num_to_state(lightStates[2]).c_str());
+
+    return hardware_interface::return_type::OK;
+  }
+
+  hardware_interface::return_type StatusLight::write(const rclcpp::Time &, const rclcpp::Duration &)
+  {
+
+    TeensyMessage message = TeensyMessage_init_zero;
+    pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+
+    uint8_t selected_color = static_cast<uint8_t>(signals[0]);
+    uint8_t selected_state = static_cast<uint8_t>(signals[1]);
+    if (selected_color >= 0 && selected_color <= 2 && selected_state >= 0 && selected_state <= 2)
+    {
+      lightStates[selected_color] = selected_state;
+    }
+
+    message.redEnabled = (lightStates[0] != 0);
+    message.redBlink = (lightStates[0] == 2);
+    message.greenEnabled = (lightStates[1] != 0);
+    message.greenBlink = (lightStates[1] == 2);
+    message.blueEnabled = (lightStates[2] != 0);
+    message.blueBlink = (lightStates[2] == 2);
+
+    // Fill Required Fields
+    message.m1Setpoint = 0;
+    message.m2Setpoint = 0;
+    message.m3Setpoint = 0;
+    message.m4Setpoint = 0;
+    message.m5Setpoint = 0;
+    message.m6Setpoint = 0;
+
+    // Set message id to status light
+    message.messageID = 1;
+
+    bool status = pb_encode(&stream, TeensyMessage_fields, &message);
+    message_length = stream.bytes_written;
+
+    if (!status)
+    {
+      return hardware_interface::return_type::ERROR;
+    }
+    udp_->Send((char *)buffer, sizeof(buffer));
+    return hardware_interface::return_type::OK;
+  }
+
+} // namespace urc_hardware::hardware_interfaces

--- a/urc_hw_description/urdf/ros2_control.xacro
+++ b/urc_hw_description/urdf/ros2_control.xacro
@@ -175,7 +175,7 @@
         </hardware>
         <gpio name="status_light">
           <command_interface name="color" />
-          <command_interface name="display" />
+          <command_interface name="state" />
         </gpio>
       </ros2_control>
       <ros2_control name="battery_management" type="sensor">

--- a/urc_msgs/CMakeLists.txt
+++ b/urc_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/BatteryInfo.msg"
   "msg/Waypoint.msg"
   "msg/NavigationStatus.msg"
+  "msg/StatusLightCommand.msg"
   "msg/GridLocation.msg"
   "srv/GeneratePlan.srv"
   "action/FollowPath.action"

--- a/urc_msgs/msg/StatusLightCommand.msg
+++ b/urc_msgs/msg/StatusLightCommand.msg
@@ -1,0 +1,10 @@
+uint8 RED=0
+uint8 GREEN=1
+uint8 BLUE=2
+
+uint8 OFF=0
+uint8 ON=1
+uint8 BLINK=2
+
+uint8 color
+uint8 state


### PR DESCRIPTION
# Description
This PR unifies the status light interface into a single topic with a custom message type. This is a much cleaner implementation, and does not affect any of the actual functionality.

Expectation: Should be a no-op in terms of the status light functionality.

# Self Checklist
- [x] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
