### PR TITLE
[sim] Added 3D LiDAR to simulation

### DIFF
--- a/urc_hw_description/urdf/walli_sensors.xacro
+++ b/urc_hw_description/urdf/walli_sensors.xacro
@@ -139,7 +139,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <cylinder radius="0.0508" length="0.055" />
+        <cylinder radius="0.05" length="0.0985" />
       </geometry>
     </visual>
   </link>
@@ -152,7 +152,7 @@
   <gazebo reference="lidar_link">
     <sensor name="lidar" type="ray">
       <always_on>true</always_on>
-      <visualize>true</visualize>
+      <visualize>false</visualize>
       <update_rate>5</update_rate>
       <ray>
         <scan>

--- a/urc_hw_description/urdf/walli_sensors.xacro
+++ b/urc_hw_description/urdf/walli_sensors.xacro
@@ -124,10 +124,10 @@
   </gazebo>
 
   <!-- LIDAR -->
-  <!-- <link name="lidar_link">
+  <link name="lidar_link">
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0" />
-      <mass value="0.125" />
+      <mass value="0.025" />
       <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001" />
     </inertial>
     <collision>
@@ -162,6 +162,12 @@
             <min_angle>0.000000</min_angle>
             <max_angle>6.280000</max_angle>
           </horizontal>
+          <vertical>
+            <samples>10</samples>
+            <resolution>1.000000</resolution>
+            <min_angle>0.000000</min_angle>
+            <max_angle>0.5000</max_angle>
+          </vertical>
         </scan>
         <range>
           <min>0.12</min>
@@ -178,11 +184,11 @@
         <ros>
           <remapping>~/out:=scan</remapping>
         </ros>
-        <output_type>sensor_msgs/LaserScan</output_type>
+        <output_type>sensor_msgs/PointCloud2</output_type>
         <frame_name>lidar_link</frame_name>
       </plugin>
     </sensor>
-  </gazebo> -->
+  </gazebo>
 
   <!-- May want to change this to a depth camera -->
   <xacro:macro name="camera" params="orientation origin_x origin_y origin_z yaw">

--- a/urc_hw_description/urdf/walli_sensors.xacro
+++ b/urc_hw_description/urdf/walli_sensors.xacro
@@ -127,7 +127,7 @@
   <link name="lidar_link">
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0" />
-      <mass value="0.025" />
+      <mass value="0.7" />
       <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001" />
     </inertial>
     <collision>
@@ -163,10 +163,10 @@
             <max_angle>6.280000</max_angle>
           </horizontal>
           <vertical>
-            <samples>10</samples>
+            <samples>16</samples>
             <resolution>1.000000</resolution>
-            <min_angle>0.000000</min_angle>
-            <max_angle>0.5000</max_angle>
+            <min_angle>-.12566</min_angle>
+            <max_angle>0.59865</max_angle>
           </vertical>
         </scan>
         <range>


### PR DESCRIPTION
# Description

Added 3D LIDAR functionality in simulation. Publishes a `PointCloud2` message to the `/scan` topic.

# Testing Steps

Tested by launching the simulation and viewing the resulting `PointCloud2` message in RViz.

Expectation: The thing which does the thing does the thing

# Self Checklist
- [ ] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
