### PR TITLE
Remove duplicate twist mux

### DIFF
--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -94,6 +94,7 @@ def generate_launch_description():
         package="urc_platform",
         executable="urc_platform_TwistMux",
         name="twist_mux",
+        parameters=[twist_mux_config],
     )
 
     launch_gps = IncludeLaunchDescription(

--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -124,15 +124,6 @@ def generate_launch_description():
         parameters=[{"port": 9090}],
     )
 
-    twist_mux_node = Node(
-        package="twist_mux",
-        executable="twist_mux",
-        name="twist_mux",
-        output="screen",
-        parameters=[twist_mux_config],
-        remappings=[("/cmd_vel_out", "/rover_drivetrain_controller/cmd_vel")],
-    )
-
     odom_frame_node = Node(
         package="urc_tf", executable="urc_tf_WorldFrameBroadcaster", output="screen"
     )


### PR DESCRIPTION
# Description
This PR does the following:
- Removes duplicate twist mux node from bringup.

# Testing Steps (if relevant)
## Test Case 1
1. Run bringup
2. Run `ros2 topic echo /rover_drivetrain_controller/cmd_vel`. There should be no error related to multiple message types on the topic.

# Self Checklist
- [X] I have formatted my code using `ament_uncrustify --reformat`
- [X] I have tested that the new behavior works 
