### PR TITLE
Update code to work with 4 wheeled rover

### DIFF
--- a/urc_bringup/config/ros2_control_walli.yaml
+++ b/urc_bringup/config/ros2_control_walli.yaml
@@ -45,18 +45,8 @@ status_light_controller:
 
 rover_drivetrain_controller:
   ros__parameters:
-    left_wheel_names:
-      [
-        "left_front_wheel_joint",
-        "left_center_wheel_joint",
-        "left_rear_wheel_joint",
-      ]
-    right_wheel_names:
-      [
-        "right_front_wheel_joint",
-        "right_center_wheel_joint",
-        "right_rear_wheel_joint",
-      ]
+    left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
+    right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
 
     wheel_separation: 0.70
     wheels_per_side: 3

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -133,11 +133,9 @@ hardware_interface::return_type RoverDrivetrain::write(
 
   message.m1Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
   message.m2Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
-  message.m3Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
 
+  message.m3Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
   message.m4Setpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
-  message.m5Setpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
-  message.m6Setpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
 
 
   // Fill Required Fields

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -85,11 +85,11 @@ std::vector<hardware_interface::StateInterface> RoverDrivetrain::export_state_in
   state_interfaces.emplace_back("left_wheel", "velocity", &this->velocity_rps_states[0]);
   state_interfaces.emplace_back("right_wheel", "velocity", &this->velocity_rps_states[1]);
   state_interfaces.emplace_back("left_wheel", "velocity.front", &this->velocity_rps_breakdown[0]);
-  state_interfaces.emplace_back("left_wheel", "velocity.mid", &this->velocity_rps_breakdown[1]);
-  state_interfaces.emplace_back("left_wheel", "velocity.back", &this->velocity_rps_breakdown[2]);
-  state_interfaces.emplace_back("right_wheel", "velocity.front", &this->velocity_rps_breakdown[3]);
-  state_interfaces.emplace_back("right_wheel", "velocity.mid", &this->velocity_rps_breakdown[4]);
-  state_interfaces.emplace_back("right_wheel", "velocity.back", &this->velocity_rps_breakdown[5]);
+  // state_interfaces.emplace_back("left_wheel", "velocity.mid", &this->velocity_rps_breakdown[1]);
+  state_interfaces.emplace_back("left_wheel", "velocity.back", &this->velocity_rps_breakdown[1]);
+  state_interfaces.emplace_back("right_wheel", "velocity.front", &this->velocity_rps_breakdown[2]);
+  // state_interfaces.emplace_back("right_wheel", "velocity.mid", &this->velocity_rps_breakdown[4]);
+  state_interfaces.emplace_back("right_wheel", "velocity.back", &this->velocity_rps_breakdown[3]);
   return state_interfaces;
 }
 

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -132,22 +132,8 @@ hardware_interface::return_type RoverDrivetrain::write(
   // DrivetrainRequest drivetrainRequest = DrivetrainRequest_init_zero;
   pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
 
-  message.m1Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
-  message.m2Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
-
-  message.m3Setpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
-  message.m4Setpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
-
-
-  // Fill Required Fields
-  message.redEnabled = 0;
-  message.blueEnabled = 0;
-  message.greenEnabled = 0;
-  message.redBlink = 0;
-  message.blueBlink = 0;
-  message.greenBlink = 0;
-
-  message.messageID = 0;
+  message.messageType.setpointMessage.leftSetpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
+  message.messageType.setpointMessage.rightSetpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
 
   bool status = pb_encode(&stream, TeensyMessage_fields, &message);
   message_length = stream.bytes_written;

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -28,7 +28,7 @@ RoverDrivetrain::RoverDrivetrain()
 : hardware_interface_name("Rover Drivetrain")
   , velocity_rps_commands(2, 0)
   , velocity_rps_states(2, 0)
-  , velocity_rps_breakdown(6, 0)
+  , velocity_rps_breakdown(4, 0)
 {
 }
 RoverDrivetrain::~RoverDrivetrain() = default;
@@ -59,6 +59,7 @@ hardware_interface::CallbackReturn RoverDrivetrain::on_init(
 
   udp_address = info_.hardware_parameters["udp_address"];
   udp_port = info_.hardware_parameters["udp_port"];
+  // RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "UDP Address %s:%s", udp_address.c_str(), udp_port.c_str());
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }
@@ -134,7 +135,7 @@ hardware_interface::return_type RoverDrivetrain::write(
   message.m1Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
   message.m2Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
 
-  message.m3Setpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
+  message.m3Setpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
   message.m4Setpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
 
 

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -132,6 +132,7 @@ hardware_interface::return_type RoverDrivetrain::write(
   // DrivetrainRequest drivetrainRequest = DrivetrainRequest_init_zero;
   pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
 
+  message.which_messageType = TeensyMessage_setpointMessage_tag;
   message.messageType.setpointMessage.leftSetpoint = velocity_rps_commands[0] * ENCODER_CPR * -1;
   message.messageType.setpointMessage.rightSetpoint = velocity_rps_commands[1] * ENCODER_CPR * -1;
 

--- a/urc_hw/src/hardware_interfaces/status_light.cpp
+++ b/urc_hw/src/hardware_interfaces/status_light.cpp
@@ -133,21 +133,12 @@ hardware_interface::return_type StatusLight::write(const rclcpp::Time &, const r
     lightStates[selected_color] = selected_state;
   }
 
-  message.redEnabled = (lightStates[0] != 0);
-  message.redBlink = (lightStates[0] == 2);
-  message.greenEnabled = (lightStates[1] != 0);
-  message.greenBlink = (lightStates[1] == 2);
-  message.blueEnabled = (lightStates[2] != 0);
-  message.blueBlink = (lightStates[2] == 2);
-
-  // Fill Required Fields
-  message.m1Setpoint = 0;
-  message.m2Setpoint = 0;
-  message.m3Setpoint = 0;
-  message.m4Setpoint = 0;
-
-  // Set message id to status light
-  message.messageID = 1;
+  message.messageType.statusLightMessage.redEnabled = (lightStates[0] != 0);
+  message.messageType.statusLightMessage.redBlink = (lightStates[0] == 2);
+  message.messageType.statusLightMessage.greenEnabled = (lightStates[1] != 0);
+  message.messageType.statusLightMessage.greenBlink = (lightStates[1] == 2);
+  message.messageType.statusLightMessage.blueEnabled = (lightStates[2] != 0);
+  message.messageType.statusLightMessage.blueBlink = (lightStates[2] == 2);
 
   bool status = pb_encode(&stream, TeensyMessage_fields, &message);
   message_length = stream.bytes_written;

--- a/urc_hw/src/hardware_interfaces/status_light.cpp
+++ b/urc_hw/src/hardware_interfaces/status_light.cpp
@@ -145,8 +145,6 @@ hardware_interface::return_type StatusLight::write(const rclcpp::Time &, const r
   message.m2Setpoint = 0;
   message.m3Setpoint = 0;
   message.m4Setpoint = 0;
-  message.m5Setpoint = 0;
-  message.m6Setpoint = 0;
 
   // Set message id to status light
   message.messageID = 1;

--- a/urc_hw_description/urdf/ros2_control.xacro
+++ b/urc_hw_description/urdf/ros2_control.xacro
@@ -149,7 +149,7 @@
       <ros2_control name="rover_drivetrain" type="system">
         <hardware>
           <plugin>urc_hw/RoverDrivetrain</plugin>
-          <param name="udp_address">192.168.1.113</param>
+          <param name="udp_address">192.168.1.206</param>
           <param name="udp_port">8443</param>
         </hardware>
         <joint name="left_wheel">

--- a/urc_hw_description/urdf/ros2_control.xacro
+++ b/urc_hw_description/urdf/ros2_control.xacro
@@ -156,14 +156,12 @@
           <command_interface name="velocity" />
           <state_interface name="velocity" />
           <state_interface name="velocity.front" />
-          <state_interface name="velocity.mid" />
           <state_interface name="velocity.back" />
         </joint>
         <joint name="right_wheel">
           <command_interface name="velocity" />
           <state_interface name="velocity" />
           <state_interface name="velocity.front" />
-          <state_interface name="velocity.mid" />
           <state_interface name="velocity.back" />
         </joint>
       </ros2_control>

--- a/urc_nanopb/proto/urc.proto
+++ b/urc_nanopb/proto/urc.proto
@@ -10,6 +10,12 @@ message ArmEncodersMessage {
   required int32 wristSwivelTicks = 6;
 }
 
+message DriveEncodersMessage {
+  optional int32 leftSpeed = 1;
+  optional int32 rightSpeed = 2;
+  required int32 timestamp = 3;
+}
+
 message DrivetrainRequest {
   required int32 m1Setpoint = 1;
   required int32 m2Setpoint = 2;
@@ -17,27 +23,19 @@ message DrivetrainRequest {
   required int32 m4Setpoint = 4;
 }
 
-message NewStatusLightCommand {
-  required int32 redEnabled = 1;
-  required int32 blueEnabled = 2;
-  required int32 greenEnabled = 3;
-  required int32 redBlink = 4;
-  required int32 blueBlink = 5;
-  required int32 greenBlink = 6;
-}
-
-message TeensyMessage {
-  required int32 messageID = 1;
-  required int32 m1Setpoint = 2;
-  required int32 m2Setpoint = 3;
-  required int32 m3Setpoint = 4;
-  required int32 m4Setpoint = 5;
-  required int32 redEnabled = 8;
-  required int32 blueEnabled = 9;
-  required int32 greenEnabled = 10;
-  required int32 redBlink = 11;
-  required int32 blueBlink = 12;
-  required int32 greenBlink = 13;
+message DrivetrainResponse {
+  required int32 m1SpeedFeedback = 1;
+  required uint32 m1Current = 2;
+  required int32 m1PositionFeedback = 3;
+  required int32 m2SpeedFeedback = 4;
+  required uint32 m2Current = 5;
+  required int32 m2PositionFeedback = 6;
+  required int32 m3SpeedFeedback = 7;
+  required uint32 m3Current = 8;
+  required int32 m3PositionFeedback = 9;
+  required int32 m4SpeedFeedback = 10;
+  required uint32 m4Current = 11;
+  required int32 m4PositionFeedback = 12;
 }
 
 message RequestMessage {
@@ -49,99 +47,106 @@ message RequestMessage {
   required int32 timestamp = 6;
 }
 
-message IMUMessage {
-  required int32 timestamp = 1;
-
-  optional float quaternionX = 2;
-  optional float quaternionY = 3;
-  optional float quaternionZ = 4;
-  optional float quaternionW = 5;
-
-  optional float linearAccelX = 6;
-  optional float linearAccelY = 7;
-  optional float linearAccelZ = 8;
-
-  optional float angularVelocityX = 9;
-  optional float angularVelocityY = 10;
-  optional float angularVelocityZ = 11;
-}
-
-message BatteryMessage {
-  // cell voltages
-  optional float mainVoltage = 1;
-
-  optional float cell1Voltage = 2;
-  optional float cell2Voltage = 3;
-  optional float cell3Voltage = 4;
-  optional float cell4Voltage = 5;
-  optional float cell5Voltage = 6;
-  optional float cell6Voltage = 7;
-  optional float cell7Voltage = 8;
-  optional float cell8Voltage = 9;
-
-  // charge state
-  optional float chargePercentage = 10;
-
-  // discharge state
-  optional float dischargeCurrent = 11;
-}
-
-// Commands
-
 message StatusLightCommand {
   optional int32 color = 1;
   optional int32 display = 2;
 }
 
-message ScienceModuleCommand { required int32 rotateTurntable = 1; }
-
-message DriveCurrentRequest {
-  optional float leftCurrentAmps = 1;
-  optional float rightCurrentAmps = 2;
+message NewStatusLightCommand {
+  required int32 redEnabled = 1;
+  required int32 blueEnabled = 2;
+  required int32 greenEnabled = 3;
+  required int32 redBlink = 4;
+  required int32 blueBlink = 5;
+  required int32 greenBlink = 6;
 }
 
-message StatusLightRequest {
-  optional int32 color = 1;
-  optional bool blink = 2;
+// message TeensyMessage {
+//     // 0 = drivetrain
+//     // 1 = status light
+//     required int32 messageID = 1;
+//     oneof payload {
+//         DrivetrainRequest driveEncodersMessage = 2;
+//         NewStatusLightCommand statusLightCommand = 3;
+//     }
+// }
+
+// message TeensyMessage {
+//     // 0 = drivetrain
+//     // 1 = status light
+//     required int32 messageID = 1;
+//     required DrivetrainRequest driveEncodersMessage = 2;
+//     required NewStatusLightCommand statusLightCommand = 3;
+// }
+
+message StatusLightMessage {
+  required int32 lightCommand = 1;
+  /*
+  required int32 redEnabled = 1;
+  required int32 blueEnabled = 2;
+  required int32 greenEnabled = 3;
+  required int32 redBlink = 4;
+  required int32 blueBlink = 5;
+  required int32 greenBlink = 6;
+  */
 }
 
-message ArmPositionRequest {
-  required int64 shoulderTicks = 1;
-  required int64 bicepTicks = 2;
-  required int64 elbowTicks = 3;
-  required int64 wristTicks = 4;
-  required int64 clawTicks = 5;
+message SetpointMessage {
+  required int32 leftSetpoint = 1;
+  required int32 rightSetpoint = 2;
+  /*
+  required int32 m1Setpoint = 1;
+  required int32 m2Setpoint = 2;
+  required int32 m3Setpoint = 3;
+  required int32 m4Setpoint = 4;
+  required int32 m5Setpoint = 5;
+  required int32 m6Setpoint = 6;
+  */
 }
 
-message ArmClawRequest { optional int32 clawVelTicksPerSecond = 1; }
-
-message DriveFeedback {
-  optional int64 leftPosTicks = 1;
-  optional int64 rightPosTicks = 2;
-  optional int64 leftVelTicksPerSecond = 3;
-  optional int64 rightVelTicksPerSecond = 4;
-  optional int64 leftCurrentAmps = 5;
-  optional int64 rightCurrentAmps = 6;
+message TeensyMessage {
+  // 0 = drivetrain
+  // 1 = status light
+  oneof messageType {
+    StatusLightMessage statusLightMessage = 1;
+    SetpointMessage setpointMessage = 2;
+  }
+  /*
+  required int32 messageID = 1;
+  required int32 m1Setpoint           = 2;
+  required int32 m2Setpoint           = 3;
+  required int32 m3Setpoint           = 4;
+  required int32 m4Setpoint           = 5;
+  required int32 redEnabled = 8;
+  required int32 blueEnabled = 9;
+  required int32 greenEnabled = 10;
+  required int32 redBlink = 11;
+  required int32 blueBlink = 12;
+  required int32 greenBlink = 13;
+  */
 }
 
-message ArmFeedback {
-  required int64 shoulderPosTicks = 1;
-  required int64 shoulderVelTicksPerSecond = 2;
-  required int64 shoulderCurrentAmps = 3;
+message ArmClawRequest { optional int32 clawVel = 1; }
 
-  required int64 bicepPosTicks = 4;
-  required int64 bicepVelTicksPerSecond = 5;
-  required int64 bicepCurrentAmps = 6;
+message ArmEffortRequest {
+  optional int32 shoulderLiftEffort = 1;
+  optional int32 shoulderSwivelEffort = 2;
+  optional int32 elbowLiftEffort = 3;
+  optional int32 wristLiftEffort = 4;
+  optional int32 wristSwivelEffort = 5;
+  optional int32 clawVel = 6;
+}
 
-  required int64 elbowPosTicks = 7;
-  required int64 elbowVelTicksPerSecond = 8;
-  required int64 elbowCurrentAmps = 9;
+message ArmPositionFeedback {
+  optional int32 shoulderLiftTicks = 1;
+  optional int32 shoulderSwivelTicks = 2;
+  optional int32 elbowLiftTicks = 3;
+  optional int32 wristLiftTicks = 4;
+  optional int32 wristSwivelTicks = 5;
+}
 
-  required int64 wristPosTicks = 10;
-  required int64 wristVelTicksPerSecond = 11;
-  required int64 wristCurrentAmps = 12;
-
-  required int64 clawPosTicks = 13;
-  required int64 clawVelTicksPerSecond = 14;
-  required int64 clawCurrentAmps = 15;
+message ScienceMotorRequest {
+  optional int32 leadscrewVel = 1;
+  optional int32 turntableVel = 2;
+  optional int32 drillEffort = 3;
 }

--- a/urc_nanopb/proto/urc.proto
+++ b/urc_nanopb/proto/urc.proto
@@ -2,158 +2,146 @@ syntax = "proto2";
 
 // Reports the encoder ticks for each arm joint
 message ArmEncodersMessage {
-    required int32 shoulderLiftTicks    = 1;
-    required int32 shouldSwivelTicks    = 2;
-    required int32 elbowLiftTicks       = 3;
-    required int32 elbowSwivelTicks     = 4;
-    required int32 wristLiftTicks       = 5;
-    required int32 wristSwivelTicks     = 6;
+  required int32 shoulderLiftTicks = 1;
+  required int32 shouldSwivelTicks = 2;
+  required int32 elbowLiftTicks = 3;
+  required int32 elbowSwivelTicks = 4;
+  required int32 wristLiftTicks = 5;
+  required int32 wristSwivelTicks = 6;
 }
 
-message DrivetrainRequest {  
-    required int32 m1Setpoint           = 1;  
-    required int32 m2Setpoint           = 2;
-    required int32 m3Setpoint           = 3;
-    required int32 m4Setpoint           = 4;
-    required int32 m5Setpoint           = 5;
-    required int32 m6Setpoint           = 6;      
+message DrivetrainRequest {
+  required int32 m1Setpoint = 1;
+  required int32 m2Setpoint = 2;
+  required int32 m3Setpoint = 3;
+  required int32 m4Setpoint = 4;
 }
 
 message NewStatusLightCommand {
-    required int32 redEnabled = 1;
-    required int32 blueEnabled = 2;
-    required int32 greenEnabled = 3;
-    required int32 redBlink = 4;
-    required int32 blueBlink = 5;
-    required int32 greenBlink = 6;
+  required int32 redEnabled = 1;
+  required int32 blueEnabled = 2;
+  required int32 greenEnabled = 3;
+  required int32 redBlink = 4;
+  required int32 blueBlink = 5;
+  required int32 greenBlink = 6;
 }
 
 message TeensyMessage {
-    required int32 messageID = 1;
-    required int32 m1Setpoint           = 2;  
-    required int32 m2Setpoint           = 3;
-    required int32 m3Setpoint           = 4;
-    required int32 m4Setpoint           = 5;
-    required int32 m5Setpoint           = 6;
-    required int32 m6Setpoint           = 7;      
-    required int32 redEnabled = 8;
-    required int32 blueEnabled = 9;
-    required int32 greenEnabled = 10;
-    required int32 redBlink = 11;
-    required int32 blueBlink = 12;
-    required int32 greenBlink = 13;
+  required int32 messageID = 1;
+  required int32 m1Setpoint = 2;
+  required int32 m2Setpoint = 3;
+  required int32 m3Setpoint = 4;
+  required int32 m4Setpoint = 5;
+  required int32 redEnabled = 8;
+  required int32 blueEnabled = 9;
+  required int32 greenEnabled = 10;
+  required int32 redBlink = 11;
+  required int32 blueBlink = 12;
+  required int32 greenBlink = 13;
 }
 
-message RequestMessage {  
-    required bool  requestSpeed         = 1;
-    required bool  requestDiagnostics   = 2;
-    optional int32 leftSpeed            = 3;        
-    optional int32 rightSpeed           = 4;
-    optional int32 duration             = 5;
-    required int32 timestamp            = 6;
+message RequestMessage {
+  required bool requestSpeed = 1;
+  required bool requestDiagnostics = 2;
+  optional int32 leftSpeed = 3;
+  optional int32 rightSpeed = 4;
+  optional int32 duration = 5;
+  required int32 timestamp = 6;
 }
 
 message IMUMessage {
-    required int32 timestamp = 1;
+  required int32 timestamp = 1;
 
-    optional float quaternionX = 2;
-    optional float quaternionY = 3;
-    optional float quaternionZ = 4;
-    optional float quaternionW = 5;
+  optional float quaternionX = 2;
+  optional float quaternionY = 3;
+  optional float quaternionZ = 4;
+  optional float quaternionW = 5;
 
-    optional float linearAccelX = 6;
-    optional float linearAccelY = 7;
-    optional float linearAccelZ = 8;
+  optional float linearAccelX = 6;
+  optional float linearAccelY = 7;
+  optional float linearAccelZ = 8;
 
-    optional float angularVelocityX = 9;
-    optional float angularVelocityY = 10;
-    optional float angularVelocityZ = 11;
+  optional float angularVelocityX = 9;
+  optional float angularVelocityY = 10;
+  optional float angularVelocityZ = 11;
 }
-
 
 message BatteryMessage {
-    // cell voltages
-    optional float mainVoltage = 1;
+  // cell voltages
+  optional float mainVoltage = 1;
 
-    optional float cell1Voltage = 2;
-    optional float cell2Voltage = 3;
-    optional float cell3Voltage = 4;
-    optional float cell4Voltage = 5;
-    optional float cell5Voltage = 6;
-    optional float cell6Voltage = 7;
-    optional float cell7Voltage = 8;
-    optional float cell8Voltage = 9;
+  optional float cell1Voltage = 2;
+  optional float cell2Voltage = 3;
+  optional float cell3Voltage = 4;
+  optional float cell4Voltage = 5;
+  optional float cell5Voltage = 6;
+  optional float cell6Voltage = 7;
+  optional float cell7Voltage = 8;
+  optional float cell8Voltage = 9;
 
-    // charge state
-    optional float chargePercentage = 10;
-    
-    // discharge state
-    optional float dischargeCurrent = 11;
+  // charge state
+  optional float chargePercentage = 10;
+
+  // discharge state
+  optional float dischargeCurrent = 11;
 }
-
 
 // Commands
 
 message StatusLightCommand {
-    optional int32 color = 1;
-    optional int32 display = 2;
+  optional int32 color = 1;
+  optional int32 display = 2;
 }
 
-message ScienceModuleCommand {
-    required int32 rotateTurntable = 1;
-}
+message ScienceModuleCommand { required int32 rotateTurntable = 1; }
 
 message DriveCurrentRequest {
-    optional float leftCurrentAmps = 1;
-    optional float rightCurrentAmps = 2;
+  optional float leftCurrentAmps = 1;
+  optional float rightCurrentAmps = 2;
 }
 
 message StatusLightRequest {
-    optional int32 color = 1;
-    optional bool blink = 2;
+  optional int32 color = 1;
+  optional bool blink = 2;
 }
 
 message ArmPositionRequest {
-    required int64 shoulderTicks = 1;
-    required int64 bicepTicks = 2;
-    required int64 elbowTicks = 3;
-    required int64 wristTicks = 4;
-    required int64 clawTicks = 5;
+  required int64 shoulderTicks = 1;
+  required int64 bicepTicks = 2;
+  required int64 elbowTicks = 3;
+  required int64 wristTicks = 4;
+  required int64 clawTicks = 5;
 }
 
-message ArmClawRequest {
-    optional int32 clawVelTicksPerSecond = 1;
-}
+message ArmClawRequest { optional int32 clawVelTicksPerSecond = 1; }
 
 message DriveFeedback {
-    optional int64 leftPosTicks = 1;
-    optional int64 rightPosTicks = 2;
-    optional int64 leftVelTicksPerSecond = 3;
-    optional int64 rightVelTicksPerSecond = 4;
-    optional int64 leftCurrentAmps = 5;
-    optional int64 rightCurrentAmps = 6;
+  optional int64 leftPosTicks = 1;
+  optional int64 rightPosTicks = 2;
+  optional int64 leftVelTicksPerSecond = 3;
+  optional int64 rightVelTicksPerSecond = 4;
+  optional int64 leftCurrentAmps = 5;
+  optional int64 rightCurrentAmps = 6;
 }
 
 message ArmFeedback {
-    required int64 shoulderPosTicks = 1;
-    required int64 shoulderVelTicksPerSecond = 2;
-    required int64 shoulderCurrentAmps = 3;
+  required int64 shoulderPosTicks = 1;
+  required int64 shoulderVelTicksPerSecond = 2;
+  required int64 shoulderCurrentAmps = 3;
 
-    required int64 bicepPosTicks = 4;
-    required int64 bicepVelTicksPerSecond = 5;
-    required int64 bicepCurrentAmps = 6;
+  required int64 bicepPosTicks = 4;
+  required int64 bicepVelTicksPerSecond = 5;
+  required int64 bicepCurrentAmps = 6;
 
-    required int64 elbowPosTicks = 7;
-    required int64 elbowVelTicksPerSecond = 8;
-    required int64 elbowCurrentAmps = 9;
+  required int64 elbowPosTicks = 7;
+  required int64 elbowVelTicksPerSecond = 8;
+  required int64 elbowCurrentAmps = 9;
 
-    required int64 wristPosTicks = 10;
-    required int64 wristVelTicksPerSecond = 11;
-    required int64 wristCurrentAmps = 12;
+  required int64 wristPosTicks = 10;
+  required int64 wristVelTicksPerSecond = 11;
+  required int64 wristCurrentAmps = 12;
 
-    required int64 clawPosTicks = 13;
-    required int64 clawVelTicksPerSecond = 14;
-    required int64 clawCurrentAmps = 15;
+  required int64 clawPosTicks = 13;
+  required int64 clawVelTicksPerSecond = 14;
+  required int64 clawCurrentAmps = 15;
 }
-
-

--- a/urc_nanopb/proto/urc.proto
+++ b/urc_nanopb/proto/urc.proto
@@ -80,15 +80,13 @@ message NewStatusLightCommand {
 // }
 
 message StatusLightMessage {
-  required int32 lightCommand = 1;
-  /*
+  // required int32 lightCommand = 1;
   required int32 redEnabled = 1;
   required int32 blueEnabled = 2;
   required int32 greenEnabled = 3;
   required int32 redBlink = 4;
   required int32 blueBlink = 5;
   required int32 greenBlink = 6;
-  */
 }
 
 message SetpointMessage {
@@ -103,6 +101,45 @@ message SetpointMessage {
   required int32 m6Setpoint = 6;
   */
 }
+
+message BatteryMessage {
+  // cell voltages
+  optional float mainVoltage = 1;
+
+  optional float cell1Voltage = 2;
+  optional float cell2Voltage = 3;
+  optional float cell3Voltage = 4;
+  optional float cell4Voltage = 5;
+  optional float cell5Voltage = 6;
+  optional float cell6Voltage = 7;
+  optional float cell7Voltage = 8;
+  optional float cell8Voltage = 9;
+
+  // charge state
+  optional float chargePercentage = 10;
+
+  // discharge state
+  optional float dischargeCurrent = 11;
+}
+
+message IMUMessage {
+  required int32 timestamp = 1;
+
+  optional float quaternionX = 2;
+  optional float quaternionY = 3;
+  optional float quaternionZ = 4;
+  optional float quaternionW = 5;
+
+  optional float linearAccelX = 6;
+  optional float linearAccelY = 7;
+  optional float linearAccelZ = 8;
+
+  optional float angularVelocityX = 9;
+  optional float angularVelocityY = 10;
+  optional float angularVelocityZ = 11;
+}
+
+message ScienceModuleCommand { required int32 rotateTurntable = 1; }
 
 message TeensyMessage {
   // 0 = drivetrain


### PR DESCRIPTION
# Description
This PR does the following:
- Updates code, mainly in `urc_hw` to work with 4 wheels instead of 6.
- Use oneof mesages for TeensyMessage

# Testing Steps (if relevant)
## Test Case 1
1. Connect to the rover router and SSH into the NUC.
2. Run bringup on the NUC.
3. Connect an Xbox controller and run `ros2 launch urc_bringup teleop.launch.py` on your host laptop
4. Run `ros2 topic pub /cmd_vel_mode std_msgs/msg/String "{data: 'teleop'}"` (This puts the `twist_mux` in teleoperation mode
5. The rover should drive around in response to the Xbox controller.

# Self Checklist
- [X] I have formatted my code using `ament_uncrustify --reformat`
- [X] I have tested that the new behavior works 
