### PR TITLE
[firmware] wheel encoder feedback

### DIFF
--- a/urc_bringup/config/controller_config.yaml
+++ b/urc_bringup/config/controller_config.yaml
@@ -48,7 +48,7 @@ rover_drivetrain_controller:
     left_wheel_names: ["left_wheel"]
     right_wheel_names: ["right_wheel"]
 
-    wheel_separation: 0.78
+    wheel_separation: 0.73025
     # wheels_per_side: 1  # actually 2, but both are controlled by 1 signal
     wheel_radius: 0.12
 

--- a/urc_bringup/config/controller_config.yaml
+++ b/urc_bringup/config/controller_config.yaml
@@ -64,7 +64,7 @@ rover_drivetrain_controller:
 
     open_loop: true
     enable_odom_tf: true
-    position_feedback: false
+    position_feedback: true
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true

--- a/urc_bringup/config/controller_config.yaml
+++ b/urc_bringup/config/controller_config.yaml
@@ -49,7 +49,7 @@ rover_drivetrain_controller:
     right_wheel_names: ["right_wheel"]
 
     wheel_separation: 0.78
-    #wheels_per_side: 1  # actually 2, but both are controlled by 1 signal
+    # wheels_per_side: 1  # actually 2, but both are controlled by 1 signal
     wheel_radius: 0.12
 
     wheel_separation_multiplier: 1.0
@@ -62,7 +62,7 @@ rover_drivetrain_controller:
     pose_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
     twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 
-    open_loop: true
+    open_loop: false
     enable_odom_tf: false
     position_feedback: false
 

--- a/urc_bringup/config/controller_config.yaml
+++ b/urc_bringup/config/controller_config.yaml
@@ -63,8 +63,8 @@ rover_drivetrain_controller:
     twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 
     open_loop: true
-    enable_odom_tf: true
-    position_feedback: true
+    enable_odom_tf: false
+    position_feedback: false
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true

--- a/urc_hw/include/urc_hw/hardware_interfaces/rover_drivetrain.hpp
+++ b/urc_hw/include/urc_hw/hardware_interfaces/rover_drivetrain.hpp
@@ -1,6 +1,7 @@
 #ifndef URC_HW__URC_ROVER_DRIVETRAIN_HPP
 #define URC_HW__URC_ROVER_DRIVETRAIN_HPP
 
+#include "async_sockets/udpserver.hpp"
 #include "memory"
 #include "vector"
 #include "string"
@@ -8,8 +9,6 @@
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "async_sockets/basesocket.hpp"
-#include "async_sockets/udpsocket.hpp"
 #include "pb_encode.h"
 #include "urc_nanopb/urc.pb.h"
 #include <cstdint>
@@ -69,8 +68,9 @@ private:
   std::vector<double> velocity_rps_breakdown;
 
   // hardware resources
-  std::shared_ptr<UDPSocket<128>> udp_;
+  std::shared_ptr<UDPServer<128>> udp_;
   std::string udp_address;
+  std::string udp_self_address;
   std::string udp_port;
 
   // nanopb

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -93,34 +93,34 @@ hardware_interface::CallbackReturn RoverDrivetrain::on_activate(const rclcpp_lif
 {
   udp_ = std::make_shared<UDPServer<128>>();
   udp_->Bind(udp_self_address.c_str(), std::stoi(udp_port));
-  udp_->onRawMessageReceived = [this](const char* buf, ssize_t size, std::string, std::uint16_t) {
-    DrivetrainResponse message = DrivetrainResponse_init_zero;
+  udp_->onRawMessageReceived = [this](const char * buf, ssize_t size, std::string, std::uint16_t) {
+      DrivetrainResponse message = DrivetrainResponse_init_zero;
 
-    pb_istream_t stream = pb_istream_from_buffer((unsigned char *) buf, size);
-    bool status = pb_decode(&stream, DrivetrainResponse_fields, &message);
+      pb_istream_t stream = pb_istream_from_buffer((unsigned char *) buf, size);
+      bool status = pb_decode(&stream, DrivetrainResponse_fields, &message);
 
-    if (!status) {
-      RCLCPP_ERROR(
-        rclcpp::get_logger(hardware_interface_name),
-        "Error while decoding wheel encoder feedback message.");
-      return;
-    }
-    message.m4SpeedFeedback *= -1; // feedback is reversed
-    message.m2SpeedFeedback *= -1; // feedback is reversed
-    // RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "%d %d %d %d", message.m1SpeedFeedback, message.m2SpeedFeedback, message.m3SpeedFeedback, message.m4SpeedFeedback);
-    if (std::abs(message.m1SpeedFeedback) < std::abs(message.m2SpeedFeedback)) {
-      this->velocity_rps_states[0] = message.m1SpeedFeedback;
-    } else {
-      this->velocity_rps_states[0] = message.m2SpeedFeedback;
-    }
-    if (std::abs(message.m3SpeedFeedback) < std::abs(message.m4SpeedFeedback)) {
-      this->velocity_rps_states[1] = message.m3SpeedFeedback;
-    } else {
-      this->velocity_rps_states[1] = message.m4SpeedFeedback;
-    }
-    this->velocity_rps_states[0] /= ENCODER_CPR;
-    this->velocity_rps_states[1] /= ENCODER_CPR;
-  };
+      if (!status) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger(hardware_interface_name),
+          "Error while decoding wheel encoder feedback message.");
+        return;
+      }
+      message.m4SpeedFeedback *= -1; // feedback is reversed
+      message.m2SpeedFeedback *= -1; // feedback is reversed
+      // RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "%d %d %d %d", message.m1SpeedFeedback, message.m2SpeedFeedback, message.m3SpeedFeedback, message.m4SpeedFeedback);
+      if (std::abs(message.m1SpeedFeedback) < std::abs(message.m2SpeedFeedback)) {
+        this->velocity_rps_states[0] = message.m1SpeedFeedback;
+      } else {
+        this->velocity_rps_states[0] = message.m2SpeedFeedback;
+      }
+      if (std::abs(message.m3SpeedFeedback) < std::abs(message.m4SpeedFeedback)) {
+        this->velocity_rps_states[1] = message.m3SpeedFeedback;
+      } else {
+        this->velocity_rps_states[1] = message.m4SpeedFeedback;
+      }
+      this->velocity_rps_states[0] /= ENCODER_CPR;
+      this->velocity_rps_states[1] /= ENCODER_CPR;
+    };
 
   udp_->Connect(udp_address, std::stoi(udp_port));
   RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Rover Drivetrain activated!");

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -105,17 +105,21 @@ hardware_interface::CallbackReturn RoverDrivetrain::on_activate(const rclcpp_lif
         "Error while decoding wheel encoder feedback message.");
       return;
     }
-    message.m3SpeedFeedback *= -1; // feedback is reversed
+    message.m4SpeedFeedback *= -1; // feedback is reversed
+    message.m2SpeedFeedback *= -1; // feedback is reversed
+    // RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "%d %d %d %d", message.m1SpeedFeedback, message.m2SpeedFeedback, message.m3SpeedFeedback, message.m4SpeedFeedback);
     if (std::abs(message.m1SpeedFeedback) < std::abs(message.m2SpeedFeedback)) {
-      this->velocity_rps_breakdown[0] = message.m1SpeedFeedback;
+      this->velocity_rps_states[0] = message.m1SpeedFeedback;
     } else {
-      this->velocity_rps_breakdown[0] = message.m2SpeedFeedback;
+      this->velocity_rps_states[0] = message.m2SpeedFeedback;
     }
     if (std::abs(message.m3SpeedFeedback) < std::abs(message.m4SpeedFeedback)) {
-      this->velocity_rps_breakdown[1] = message.m3SpeedFeedback;
+      this->velocity_rps_states[1] = message.m3SpeedFeedback;
     } else {
-      this->velocity_rps_breakdown[1] = message.m4SpeedFeedback;
+      this->velocity_rps_states[1] = message.m4SpeedFeedback;
     }
+    this->velocity_rps_states[0] *= (2*M_PI/ENCODER_CPR);
+    this->velocity_rps_states[1] *= (2*M_PI/ENCODER_CPR);
   };
 
   udp_->Connect(udp_address, std::stoi(udp_port));

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -93,7 +93,7 @@ std::vector<hardware_interface::StateInterface> RoverDrivetrain::export_state_in
 
 hardware_interface::CallbackReturn RoverDrivetrain::on_activate(const rclcpp_lifecycle::State &)
 {
-  udp_ = std::make_shared<UDPServer<128>>(true);
+  udp_ = std::make_shared<UDPServer<128>>();
   udp_->Bind(udp_self_address.c_str(), std::stoi(udp_port));
   udp_->onMessageReceived = [this](std::string message, std::string ip, std::uint16_t port) {
     RCLCPP_INFO(rclcpp::get_logger(hardware_interface_name), "Received %s from %s:%d.", message.c_str(), ip.c_str(), port);

--- a/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
+++ b/urc_hw/src/hardware_interfaces/rover_drivetrain.cpp
@@ -118,8 +118,8 @@ hardware_interface::CallbackReturn RoverDrivetrain::on_activate(const rclcpp_lif
     } else {
       this->velocity_rps_states[1] = message.m4SpeedFeedback;
     }
-    this->velocity_rps_states[0] *= (2*M_PI/ENCODER_CPR);
-    this->velocity_rps_states[1] *= (2*M_PI/ENCODER_CPR);
+    this->velocity_rps_states[0] /= ENCODER_CPR;
+    this->velocity_rps_states[1] /= ENCODER_CPR;
   };
 
   udp_->Connect(udp_address, std::stoi(udp_port));

--- a/urc_hw_description/urdf/ros2_control.xacro
+++ b/urc_hw_description/urdf/ros2_control.xacro
@@ -149,8 +149,9 @@
       <ros2_control name="rover_drivetrain" type="system">
         <hardware>
           <plugin>urc_hw/RoverDrivetrain</plugin>
-          <param name="udp_address">192.168.1.206</param>
+          <param name="udp_address">192.168.1.119</param>
           <param name="udp_port">8443</param>
+          <param name="udp_self_address">192.168.1.150</param>
         </hardware>
         <joint name="left_wheel">
           <command_interface name="velocity" />


### PR DESCRIPTION
# Description
This PR does the following:
- Wheel encoder feedback

# Testing Steps (if relevant)
## Test Case 1
1. Run bringup on the rover
2. Run `ros2 topic echo /rover_drivetrain_controller/odom` to look at the position and twist values.
3. Move the rover, either using the Xbox controller or manually publishing to the `/rover_drivetrain_controller/cmd_vel` topic.

Expectation: Odometry from the rover should be accurate, not accouting for wheel slippage.

# Self Checklist
- [X] I have formatted my code using `ament_uncrustify --reformat`
- [X] I have tested that the new behavior works 
