### PR TITLE
[misc] update sensor static transformations

### DIFF
--- a/urc_bringup/config/vectornav_imu.yaml
+++ b/urc_bringup/config/vectornav_imu.yaml
@@ -1,0 +1,70 @@
+vectornav:
+  ros__parameters:
+    port: "/dev/ttyUSB0"
+    baud: 115200
+    reconnect_ms: 500
+    # Reference vnproglib-1.2.0.0 headers for enum definitions
+    # Async Output Type (ASCII)
+    AsyncDataOutputType: 0 # VNOFF
+    # Async output Frequency (Hz)
+    AsyncDataOutputFrequency: 20
+    # Sync control
+    syncInMode: 3 # SYNCINMODE_COUNT
+    syncInEdge: 0 # SYNCINEDGE_RISING
+    syncInSkipFactor: 0
+    syncOutMode: 0 # SYNCOUTMODE_NONE
+    syncOutPolarity: 0 # SYNCOUTPOLARITY_NEGATIVE
+    syncOutSkipFactor: 0
+    syncOutPulseWidth_ns: 100000000
+    # Communication protocol control
+    serialCount: 0 # COUNTMODE_NONE
+    serialStatus: 0 # STATUSMODE_OFF
+    spiCount: 0 # COUNTMODE_NONE
+    spiStatus: 0 # STATUSMODE_OFF
+    serialChecksum: 1 # CHECKSUMMODE_CHECKSUM
+    spiChecksum: 0 # CHECKSUMMODE_OFF
+    errorMode: 1 # ERRORMODE_SEND
+    # Binary output register 1
+    BO1:
+      asyncMode: 3 # ASYNCMODE_BOTH
+      rateDivisor: 40 # 20 Hz
+      commonField: 0x7FFF
+      timeField: 0x0000 # TIMEGROUP_NONE
+      imuField: 0x0000 # IMUGROUP_NONE
+      # set gpsField directly in source to enforce or condition
+      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
+      # set insField directly in source to enforce or condition
+      gps2Field: 0x0000 # GPSGROUP_NONE
+    # Binary output register 2
+    BO2:
+      asyncMode: 0 # ASYNCMODE_NONE
+      rateDivisor: 0
+      commonField: 0x0000 # COMMONGROUP_NONE
+      timeField: 0x0000 # TIMEGROUP_NONE
+      imuField: 0x0000 # IMUGROUP_NONE
+      gpsField: 0x0000 # GPSGROUP_NONE
+      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
+      insField: 0x0000 # INSGROUP_NONE
+      gps2Field: 0x0000 # GPSGROUP_NONE
+    # Binary output register 3
+    BO3:
+      asyncMode: 0 # ASYNCMODE_NONE
+      rateDivisor: 0
+      commonField: 0x0000 # COMMONGROUP_NONE
+      timeField: 0x0000 # TIMEGROUP_NONE
+      imuField: 0x0000 # IMUGROUP_NONE
+      gpsField: 0x0000 # GPSGROUP_NONE
+      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
+      insField: 0x0000 # INSGROUP_NONE
+      gps2Field: 0x0000 # GPSGROUP_NONE
+    frame_id: "imu_link"
+
+vn_sensor_msgs:
+  ros__parameters:
+    use_enu: true
+    orientation_covariance: [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+    angular_velocity_covariance:
+      [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+    linear_acceleration_covariance:
+      [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+    magnetic_covariance: [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]

--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -122,7 +122,9 @@ def generate_launch_description():
         package='vectornav', 
         executable='vn_sensor_msgs',
         output='screen',
-        parameters=[os.path.join(pkg_urc_bringup, 'config', 'vectornav_imu.yaml')])
+        parameters=[os.path.join(pkg_urc_bringup, 'config', 'vectornav_imu.yaml')],
+        remappings=[("/vectornav/imu", "/imu/data")]
+    )
 
     rosbridge_server_node = Node(
         package="rosbridge_server",

--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -112,11 +112,17 @@ def generate_launch_description():
         parameters=[gps_config],
     )
 
-    launch_vectornav = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_vectornav, "launch", "vectornav.launch.py")
-        )
-    )
+    vectornav_node = Node(
+        package='vectornav', 
+        executable='vectornav',
+        output='screen',
+        parameters=[os.path.join(pkg_urc_bringup, 'config', 'vectornav_imu.yaml')])
+    
+    vectornav_sensor_msg_node = Node(
+        package='vectornav', 
+        executable='vn_sensor_msgs',
+        output='screen',
+        parameters=[os.path.join(pkg_urc_bringup, 'config', 'vectornav_imu.yaml')])
 
     rosbridge_server_node = Node(
         package="rosbridge_server",
@@ -150,7 +156,8 @@ def generate_launch_description():
             launch_gps,
             rosbridge_server_node,
             odom_frame_node,
-            launch_vectornav,
+            vectornav_node,
+            vectornav_sensor_msg_node,
             heartbeat_node,
         ]
     )

--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -116,7 +116,9 @@ def generate_launch_description():
         package='vectornav', 
         executable='vectornav',
         output='screen',
-        parameters=[os.path.join(pkg_urc_bringup, 'config', 'vectornav_imu.yaml')])
+        parameters=[os.path.join(pkg_urc_bringup, 'config', 'vectornav_imu.yaml')],
+        remappings=[("/vectornav/imu", "/imu/data")]
+    )
     
     vectornav_sensor_msg_node = Node(
         package='vectornav', 

--- a/urc_hw_description/urdf/walli_sensors.xacro
+++ b/urc_hw_description/urdf/walli_sensors.xacro
@@ -90,7 +90,7 @@
   </gazebo>
 
   <!-- GPS -->
-  <link name="gps">
+  <link name="gps_link">
     <visual>
       <geometry>
         <box size="0.05 0.05 0.05" />

--- a/urc_hw_description/urdf/walli_sensors.xacro
+++ b/urc_hw_description/urdf/walli_sensors.xacro
@@ -16,7 +16,7 @@
   </link>
   <joint name="imu_joint" type="fixed">
     <axis xyz="1 0 0" />
-    <origin xyz="0.05 0.1 0.2" />
+    <origin xyz="-0.32 -0.09 0.0" />
     <parent link="base_link" />
     <child link="imu_link" />
   </joint>
@@ -105,7 +105,7 @@
   </link>
   <joint name="gps_joint" type="fixed">
     <axis xyz="1 0 0" />
-    <origin xyz="0.05 -0.1 0.2" />
+    <origin xyz="-0.39 -0.27 0.34" />
     <parent link="base_link" />
     <child link="gps" />
   </joint>

--- a/urc_hw_description/urdf/walli_sensors.xacro
+++ b/urc_hw_description/urdf/walli_sensors.xacro
@@ -107,7 +107,7 @@
     <axis xyz="1 0 0" />
     <origin xyz="-0.39 -0.27 0.34" />
     <parent link="base_link" />
-    <child link="gps" />
+    <child link="gps_link" />
   </joint>
   <gazebo reference="gps">
     <sensor name="gps" type="gps">
@@ -116,7 +116,7 @@
           <namespace>/gps</namespace>
           <remapping>~/out:=data</remapping>
         </ros>
-        <frame_name>gps</frame_name>
+        <frame_name>gps_link</frame_name>
       </plugin>
       <always_on>true</always_on>
       <updateRate>30</updateRate>


### PR DESCRIPTION
# Description
This PR does the following:
- Updates GPS and IMU link positions in the TF tree according to the new positions in the physical rover.

# Testing Steps (if relevant)
## Test Case 1
1. Run bringup
2. Look at the transforms in Rviz. The GPS should be to the back, right, and raised from base link, and the IMU should be to the back, and slightly to the right.
3. IMU data should be in the imu_link frame.

# Self Checklist
- [X] I have formatted my code using `ament_uncrustify --reformat`
- [X] I have tested that the new behavior works 
