### PR TITLE
Invoked launch file for multiscan100

### DIFF
--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -127,6 +127,13 @@ def generate_launch_description():
         parameters=[os.path.join(pkg_urc_bringup, 'config', 'vectornav_imu.yaml')],
         remappings=[("/vectornav/imu", "/imu/data")]
     )
+    
+    sick_scan_multiscan_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(get_package_share_directory("sick_scan"), "launch", "sick_scan_multiscan.launch.py")
+        ),
+        launch_arguments={'publish_frame_id': 'lidar_link'}.items()
+    )
 
     rosbridge_server_node = Node(
         package="rosbridge_server",
@@ -163,5 +170,6 @@ def generate_launch_description():
             vectornav_node,
             vectornav_sensor_msg_node,
             heartbeat_node,
+            sick_scan_multiscan_launch
         ]
     )

--- a/urc_hw_description/urdf/walli_sensors.xacro
+++ b/urc_hw_description/urdf/walli_sensors.xacro
@@ -124,7 +124,7 @@
   </gazebo>
 
   <!-- LIDAR -->
-  <!-- <link name="lidar_link">
+  <link name="lidar_link">
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <mass value="0.125" />
@@ -149,7 +149,7 @@
     <origin xyz="0.0 0.0 0.25" rpy="0.0 0.0 0.0" />
   </joint>
 
-  <gazebo reference="lidar_link">
+  <!--<gazebo reference="lidar_link">
     <sensor name="lidar" type="ray">
       <always_on>true</always_on>
       <visualize>true</visualize>


### PR DESCRIPTION
# Description
This PR intends to merge fix/lidar_frame with the master brnach:
- Creates link "lidar_link" in walli_sensors.xacro
- Invokes the sick_multiscan.launch file from sick_scan_xd (Default frame_id changed to lidar_link instead of world)