### PR TITLE
switch to https github link in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,5 +27,5 @@
 	branch = ros2
 [submodule "external/ublox_dgnss"]
 	path = external/ublox_dgnss
-	url = git@github.com:aussierobots/ublox_dgnss.git
+	url = https://github.com/aussierobots/ublox_dgnss.git
 	branch = main


### PR DESCRIPTION
# Description
This PR does the following:
- Replaces SSH link with HTTPS link, so that people can setup the codebase even if they don't have SSH Github authentication set up.

# Self Checklist
- [X] I have formatted my code using `ament_uncrustify --reformat`
- [X] I have tested that the new behavior works 
