### PR TITLE
[launch] fix some bugs in `bringup` launch files

### DIFF
--- a/urc_bringup/launch/bringup.launch.py
+++ b/urc_bringup/launch/bringup.launch.py
@@ -152,18 +152,22 @@ def generate_launch_description():
         parameters=[{"port": 9090}],
     )
 
+    foxglove_launch = (
+        IncludeLaunchDescription(
+            XMLLaunchDescriptionSource(
+                [
+                    FindPackageShare("foxglove_bridge"),
+                    "/launch",
+                    "/foxglove_bridge_launch.xml",
+                ]
+            ),
+            launch_arguments={"port": "8765"}.items(),
+        ),
+    )
+
     return LaunchDescription(
         [
-            IncludeLaunchDescription(
-                XMLLaunchDescriptionSource(
-                    [
-                        FindPackageShare("foxglove_bridge"),
-                        "/launch",
-                        "/foxglove_bridge_launch.xml",
-                    ]
-                ),
-                launch_arguments={"port": "8765"}.items(),
-            ),
+            foxglove_launch,
             control_node,
             load_robot_state_publisher,
             load_joint_state_broadcaster,


### PR DESCRIPTION
# Description

In a previous PR, `teleop.launch.py` was deleted. However, `bringup_simulation.launch.py` still called this launch file. This PR removes this dependency, and also cleans up the `bringup*.launch.py` files a bit.

# Self Checklist
- [ ] I have formatted my code using `ament_uncrustify --reformat`
- [x] I have tested that the new behavior works 
