### PR TITLE
fix rviz and sim frame

### DIFF
--- a/urc_hw_description/rviz/display.rviz
+++ b/urc_hw_description/rviz/display.rviz
@@ -116,7 +116,7 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        base_Link:
+        base_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -132,7 +132,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: base_Link
+    Fixed Frame: base_link
     Frame Rate: 30
   Name: root
   Tools:

--- a/urc_hw_description/urdf/simplified_swerve/simplified_swerve_macro.xacro
+++ b/urc_hw_description/urdf/simplified_swerve/simplified_swerve_macro.xacro
@@ -9,7 +9,7 @@
   <xacro:macro name="simplified_swerve">
   
   <!-- replacing package:// -->
-  <xacro:property name="package_path" value="$(find urc_hw_description)"/>
+  <xacro:property name="package_path" value="file://$(find urc_hw_description)"/>
 
   <!-- Wheel Cylinder Geometry -->
   <xacro:property name="wheel_radius" value="0.119888" />  
@@ -19,7 +19,7 @@
   <xacro:property name="wheel_origin_xyz_right" value="0 -0.0381 0" />
     
     <link
-      name="base_Link">
+      name="base_link">
       <inertial>
         <origin
           xyz="4.08993662049939E-05 0 -0.10047242954429"
@@ -105,7 +105,7 @@
         xyz="0.070358 0.2808 -0.127"
         rpy="0 0.024048 0" />
       <parent
-        link="base_Link" />
+        link="base_link" />
       <child
         link="L_Rocker_Link" />
       <axis
@@ -381,7 +381,7 @@
         xyz="0.070358 -0.2808 -0.127"
         rpy="0 0.069977 0" />
       <parent
-        link="base_Link" />
+        link="base_link" />
       <child
         link="R_Rocker_Link" />
       <axis

--- a/urc_hw_description/urdf/simplified_swerve/simplified_swerve_ros2_control.xacro
+++ b/urc_hw_description/urdf/simplified_swerve/simplified_swerve_ros2_control.xacro
@@ -21,6 +21,14 @@
         </xacro:unless>
       </hardware>
 
+      <joint name="L_Rocker_Joint">
+        <state_interface name="position"/>
+      </joint>
+
+      <joint name="R_Rocker_Joint">
+        <state_interface name="position"/>
+      </joint>
+
       <!-- Joint State Interface -->
       <joint name="FL_Swivel_Joint">
         <command_interface name="position">
@@ -36,6 +44,7 @@
           <param name="max">100</param>
         </command_interface>
         <state_interface name="velocity"/>
+        <state_interface name="position"/>
       </joint>
 
       <joint name="BL_Swivel_Joint">
@@ -52,6 +61,7 @@
           <param name="max">100</param>
         </command_interface>
         <state_interface name="velocity"/>
+        <state_interface name="position"/>
       </joint>
 
       <joint name="FR_Swivel_Joint">
@@ -68,6 +78,7 @@
           <param name="max">100</param>
         </command_interface>
         <state_interface name="velocity"/>
+        <state_interface name="position"/>
       </joint>
 
       <joint name="BR_Swivel_Joint">
@@ -84,6 +95,7 @@
           <param name="max">100</param>
         </command_interface>
         <state_interface name="velocity"/>
+        <state_interface name="position"/>
       </joint>
 
     </ros2_control>


### PR DESCRIPTION
# Description
This PR does the following:
- Fixes TF frames (base_link frame wasn't showing up earlier)
- Fixes RobotModel visualization in Rviz2

# Testing Steps (if relevant)
## Test Case 1
1. `ros2 launch urc_bringup sim.launch.py`
2. `rviz2`
3. Add the RobotModel and TF frames in Rviz2

Expectation: There should be no errors, the tf free should look correct (according to the URDF), and the robot model should show up in rviz2.

# Self Checklist
- [X] I have formatted my code using `ament_uncrustify --reformat`
- [X] I have tested that the new behavior works 
