### PR TITLE
Add missing dependencies

### DIFF
--- a/urc_bringup/CMakeLists.txt
+++ b/urc_bringup/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(urc_msgs REQUIRED)
+find_package(ros_gz REQUIRED)
 
 include_directories(
   include
@@ -37,6 +38,7 @@ set(dependencies
   tf2_msgs
   tf2_ros
   urc_msgs
+  ros_gz
 )
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/urc_bringup/CMakeLists.txt
+++ b/urc_bringup/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(tf2_ros REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(urc_msgs REQUIRED)
 find_package(ros_gz REQUIRED)
+find_package(effort_controllers REQUIRED)
 
 include_directories(
   include
@@ -39,6 +40,7 @@ set(dependencies
   tf2_ros
   urc_msgs
   ros_gz
+  effort_controllers
 )
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/urc_bringup/package.xml
+++ b/urc_bringup/package.xml
@@ -17,6 +17,7 @@
   <depend>tf2_msgs</depend>
   <depend>urc_msgs</depend>
   <depend>ros_gz</depend>
+  <depend>effort_controller</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/urc_bringup/package.xml
+++ b/urc_bringup/package.xml
@@ -16,6 +16,7 @@
   <depend>sensor_msgs</depend>
   <depend>tf2_msgs</depend>
   <depend>urc_msgs</depend>
+  <depend>ros_gz</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/urc_bringup/package.xml
+++ b/urc_bringup/package.xml
@@ -17,7 +17,8 @@
   <depend>tf2_msgs</depend>
   <depend>urc_msgs</depend>
   <depend>ros_gz</depend>
-  <depend>effort_controller</depend>
+  <depend>effort_controllers</depend>
+  <depend>grid_map_rviz_plugin</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/urc_controllers/CMakeLists.txt
+++ b/urc_controllers/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(ros2_control REQUIRED)
 
 add_library(
   ${PROJECT_NAME}
@@ -55,6 +56,7 @@ ament_target_dependencies(
   tf2
   tf2_ros
   tf2_geometry_msgs
+  ros2_control
 )
 
 target_compile_definitions(urc_controllers PRIVATE "urc_hw_BUILDING_LIBRARY")

--- a/urc_controllers/package.xml
+++ b/urc_controllers/package.xml
@@ -19,6 +19,7 @@
   <depend>urc_msgs</depend>
   <depend>joint_trajectory_controller</depend>
   <depend>geometry_msgs</depend>
+  <depend>ros2_control</depend>
 
   <build_depend>pluginlib</build_depend>
 

--- a/urc_hw_description/CMakeLists.txt
+++ b/urc_hw_description/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(urdf REQUIRED)
 find_package(xacro REQUIRED)
+find_package(gz_ros2_control REQUIRED)
 
 install(
   DIRECTORY

--- a/urc_hw_description/CMakeLists.txt
+++ b/urc_hw_description/CMakeLists.txt
@@ -20,6 +20,8 @@ find_package(ament_cmake REQUIRED)
 find_package(urdf REQUIRED)
 find_package(xacro REQUIRED)
 find_package(gz_ros2_control REQUIRED)
+find_package(ros_gz_sim REQUIRED)
+find_package(ros_gz_bridge REQUIRED)
 
 install(
   DIRECTORY

--- a/urc_hw_description/CMakeLists.txt
+++ b/urc_hw_description/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(xacro REQUIRED)
 find_package(gz_ros2_control REQUIRED)
 find_package(ros_gz_sim REQUIRED)
 find_package(ros_gz_bridge REQUIRED)
+find_package(joint_state_broadcaster REQUIRED)
 
 install(
   DIRECTORY

--- a/urc_hw_description/package.xml
+++ b/urc_hw_description/package.xml
@@ -17,6 +17,8 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>gz_ros2_control</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>

--- a/urc_hw_description/package.xml
+++ b/urc_hw_description/package.xml
@@ -11,14 +11,15 @@
   <depend>urdf</depend>
   <depend>xacro</depend>
   <depend>urc_bringup</depend>
+  <depend>joint_state_broadcaster</depend>
   
   <!-- Launch file dependencies -->
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
-  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>

--- a/urc_hw_description/package.xml
+++ b/urc_hw_description/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>

--- a/urc_perception/CMakeLists.txt
+++ b/urc_perception/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(PCL 1.10 REQUIRED)
 find_package(grid_map_core REQUIRED)
 find_package(grid_map_ros REQUIRED)
 find_package(grid_map_msgs REQUIRED)
+find_package(grid_map_visualization REQUIRED)
 find_package(grid_map_pcl REQUIRED)
 find_package(grid_map_cv REQUIRED)
 find_package(Eigen3 REQUIRED)
@@ -65,6 +66,7 @@ set(dependencies
   grid_map_core
   grid_map_ros
   grid_map_msgs
+  grid_map_visualization
   grid_map_pcl
   grid_map_cv
   filters

--- a/urc_perception/package.xml
+++ b/urc_perception/package.xml
@@ -22,7 +22,6 @@
   <depend>tf2_sensor_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>pcl_conversions</depend>
-  <depend>pcl_1.10</depend>
   <depend>filters</depend>
   <depend>pluginlib</depend>
   <depend>rcl_interfaces</depend>

--- a/urc_perception/package.xml
+++ b/urc_perception/package.xml
@@ -29,6 +29,7 @@
   <depend>grid_map_core</depend>
   <depend>grid_map_ros</depend>
   <depend>grid_map_msgs</depend>
+  <depend>grid_map_visualization</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_cv</depend>
 


### PR DESCRIPTION
# Description
This PR does the following:
- Adds various missing dependencies so that they get installed with `rosdep` during setup